### PR TITLE
Add support for VAT calculations and site settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ the order is legitimate before using Stripe to charge the client.
 The metadata can be anywhere on the page, and goes in a script tag in this format:
 
 <script id="gocommerce-product" type="application/json">
-{"sku": "my-product", "prices": [{"amount": "49.99"}], "type": "ebook"}
+{"sku": "my-product", "title": "My Product", "prices": [{"amount": "49.99"}], "type": "ebook"}
 </script>
 
-More about what the product metadata can contain. The minimum required is the SKU and at
+More about what the product metadata can contain. The minimum required is the SKU, title and at
 least one "price". Default currency is USD if nothing else specified.
 
 ### Mail templates
@@ -70,7 +70,7 @@ Here's an example settings file:
     "countries": ["Austria", "Bulgaria", "Estonia", "France", "Gibraltar", "Slovakia", "United Kingdom"]
   }, {
     "percentage": 7,
-    "product_type": ["book"],
+    "product_types": ["book"],
     "countries": ["Austria", "Belgium", "Bulgaria", "Croatia", "Cyprus", "Denmark", "Estonia"]
   }]
 }

--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ The metadata can be anywhere on the page, and goes in a script tag in this forma
 {"sku": "my-product", "title": "My Product", "prices": [{"amount": "49.99"}], "type": "ebook"}
 </script>
 
-More about what the product metadata can contain. The minimum required is the SKU, title and at
-least one "price". Default currency is USD if nothing else specified.
+The minimum required is the SKU, title and at least one "price". Default currency is USD if nothing else specified.
 
-### Mail templates
+### Mail templates (Not implemented yet)
 
 Gocommerce will look for mail templates inside `https://yoursite.com/gocommerce/emails/`
 when sending mails to users or administrators.
@@ -50,10 +49,8 @@ Gocommerce will regularly check for a file called `https://yoursite.com/gocommer
 
 This file should have settings with rules for VAT or currency regions.
 
-This file is not required for gocommerce to work, but if you want to validate shipping/billing
-address countries/states and handle VAT calculations or limit certain prices to parts of the
-world, you should include one. You can find an example of a real world settings.json in
-`examples/settings.json`.
+This file is not required for gocommerce to work, but will enable support for various advanced
+features. Currently it enables VAT calculations on a per country/product type basic.
 
 The reason we make you include the file in the static site, is that you'll need to do the same
 VAT calculations client side during checkout to be able to show this to the user. The

--- a/README.md
+++ b/README.md
@@ -1,18 +1,85 @@
 # Gocommerce
 
-A small go based API for static ecommerce sites.
+A small go based API for static e-commerce sites.
 
-This is a simple order for creating orders with a series of line items, and then
-paying for the order with a stripe token.
+It handles orders and payments. Integrates with Stripe for payments and will support
+international pricing and VAT verification.
 
-The API will validate the price of each line item by doing a HTTP request to the
-URL for the product and verify a meta tag in this style:
+## Setting up
 
-```html
-<meta name="product:price:amount" content="4900">
+See [the example configuration](config.example.json) for an example of how to configure
+Gocommerce.
+
+The most important setting is the `site_url`. Gocommerce is always tied to a website,
+and will use the site URL to verify product prices, offers, and settings for countries,
+product types and VAT rules.
+
+Gocommerce will also look for email templates within a designated site folder and use
+the site URL to construct links to order history.
+
+Create a `config.json` file based on `config.example.json` - You must set the `site_url`
+and the `stripe_key` as a minimum.
+
+### What your static site must support
+
+Each product you want to sell from your static site must have unique URL where Gocommerce
+can find the meta data needed for calculating pricing and taxes in order to verify that
+the order is legitimate before using Stripe to charge the client.
+
+The metadata can be anywhere on the page, and goes in a script tag in this format:
+
+<script id="gocommerce-product" type="application/json">
+{"sku": "my-product", "prices": [{"amount": "49.99"}], "type": "ebook"}
+</script>
+
+More about what the product metadata can contain. The minimum required is the SKU and at
+least one "price". Default currency is USD if nothing else specified.
+
+### Mail templates
+
+Gocommerce will look for mail templates inside `https://yoursite.com/gocommerce/emails/`
+when sending mails to users or administrators.
+
+Right now the mail templates are:
+
+* **Order Confirmation** `gocommerce/emails/confirmation.html`
+
+### VAT, Countries and Regions
+
+Gocommerce will regularly check for a file called `https://yoursite.com/gocommerce/settings.json`
+
+This file should have settings with rules for VAT or currency regions.
+
+This file is not required for gocommerce to work, but if you want to validate shipping/billing
+address countries/states and handle VAT calculations or limit certain prices to parts of the
+world, you should include one. You can find an example of a real world settings.json in
+`examples/settings.json`.
+
+The reason we make you include the file in the static site, is that you'll need to do the same
+VAT calculations client side during checkout to be able to show this to the user. The
+[gocommerce-js](https://github.com/netlify/gocommerce-js) client library can help you with
+this.
+
+Here's an example settings file:
+
+```json
+{
+  "taxes": [{
+    "percentage": 20,
+    "product_types": ["ebook"],
+    "countries": ["Austria", "Bulgaria", "Estonia", "France", "Gibraltar", "Slovakia", "United Kingdom"]
+  }, {
+    "percentage": 7,
+    "product_type": ["book"],
+    "countries": ["Austria", "Belgium", "Bulgaria", "Croatia", "Cyprus", "Denmark", "Estonia"]
+  }]
+}
 ```
 
-The amount must be in cents.
+Based on these rules, if an order includes a product with "type" set to "ebook" in the product metadata
+on the site and the users billing Address is set to "Austria", Gocommerce will verify that a 20 percentage
+tax has been included in that product.
+
 
 # JavaScript Client Library
 

--- a/api/api.go
+++ b/api/api.go
@@ -20,10 +20,11 @@ var bearerRegexp = regexp.MustCompile(`^(?:B|b)earer (\S+$)`)
 
 // API is the main REST API
 type API struct {
-	handler http.Handler
-	db      *gorm.DB
-	config  *conf.Configuration
-	mailer  *mailer.Mailer
+	handler    http.Handler
+	db         *gorm.DB
+	config     *conf.Configuration
+	mailer     *mailer.Mailer
+	httpClient *http.Client
 }
 
 type JWTClaims struct {
@@ -74,7 +75,7 @@ func (a *API) ListenAndServe(hostAndPort string) error {
 
 // NewAPI instantiates a new REST API
 func NewAPI(config *conf.Configuration, db *gorm.DB, mailer *mailer.Mailer) *API {
-	api := &API{config: config, db: db, mailer: mailer}
+	api := &API{config: config, db: db, mailer: mailer, httpClient: &http.Client{}}
 	mux := kami.New()
 
 	mux.Use("/", api.withConfig)

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/netlify/gocommerce/conf"
 	"golang.org/x/net/context"
 )
 
@@ -27,6 +28,14 @@ func getToken(ctx context.Context) *jwt.Token {
 		return nil
 	}
 	return obj.(*jwt.Token)
+}
+
+func getConfig(ctx context.Context) *conf.Configuration {
+	obj := ctx.Value("config")
+	if obj == nil {
+		return nil
+	}
+	return obj.(*conf.Configuration)
 }
 
 func userIDFromToken(token *jwt.Token) string {

--- a/api/order.go
+++ b/api/order.go
@@ -50,7 +50,12 @@ func (a *API) OrderList(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	claims := token.Claims.(*JWTClaims)
 
 	var orders []models.Order
-	result := a.db.Preload("LineItems").Preload("ShippingAddress").Where("user_id = ?", claims.ID).Find(&orders)
+	result := a.db.
+		Preload("LineItems").
+		Preload("ShippingAddress").
+		Preload("BillingAddress").
+		Where("user_id = ?", claims.ID).
+		Find(&orders)
 	if result.Error != nil {
 		InternalServerError(w, fmt.Sprintf("Error during database query: %v", result.Error))
 		return

--- a/api/order.go
+++ b/api/order.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/PuerkitoBio/goquery"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/guregu/kami"
 	"github.com/jinzhu/gorm"
@@ -14,6 +15,12 @@ import (
 
 	"golang.org/x/net/context"
 )
+
+type OrderLineItem struct {
+	SKU      string `json:sku`
+	Path     string `jsonx:"path"`
+	Quantity uint64 `json:"quantity"`
+}
 
 type OrderParams struct {
 	SessionID string `json:"session_id"`
@@ -26,7 +33,11 @@ type OrderParams struct {
 	BillingAddressID string          `json:"billing_address_id"`
 	BillingAddress   *models.Address `json:"billing_address"`
 
-	LineItems []models.LineItem `json:"line_items"`
+	Data map[string]interface{} `json:"data"`
+
+	LineItems []*OrderLineItem `json:"line_items"`
+
+	Currency string `json:"currency"`
 }
 
 type verificationError struct {
@@ -88,7 +99,7 @@ func (a *API) OrderView(ctx context.Context, w http.ResponseWriter, r *http.Requ
 
 // OrderCreate endpoint
 func (a *API) OrderCreate(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	params := &OrderParams{}
+	params := &OrderParams{Currency: "USD"}
 	jsonDecoder := json.NewDecoder(r.Body)
 	err := jsonDecoder.Decode(params)
 	if err != nil {
@@ -98,7 +109,7 @@ func (a *API) OrderCreate(ctx context.Context, w http.ResponseWriter, r *http.Re
 
 	token := getToken(ctx)
 
-	order := models.NewOrder(params.SessionID, params.Email)
+	order := models.NewOrder(params.SessionID, params.Email, params.Currency)
 
 	tx := a.db.Begin()
 
@@ -108,7 +119,7 @@ func (a *API) OrderCreate(ctx context.Context, w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if httpError := a.createLineItems(tx, order, params.LineItems); httpError != nil {
+	if httpError := a.createLineItems(ctx, tx, order, params.LineItems); httpError != nil {
 		sendJSON(w, httpError.Code, httpError)
 		return
 	}
@@ -133,6 +144,14 @@ func (a *API) OrderCreate(ctx context.Context, w http.ResponseWriter, r *http.Re
 		order.BillingAddressID = billingID
 	} else {
 		order.BillingAddressID = shippingID
+	}
+
+	if params.Data != nil {
+		if err := order.UpdateOrderData(tx, &params.Data); err != nil {
+			tx.Rollback()
+			BadRequestError(w, fmt.Sprintf("Bad order metadata %v", err))
+			return
+		}
 	}
 
 	tx.Create(order)
@@ -167,17 +186,45 @@ func (a *API) setUserIDFromToken(tx *gorm.DB, user *models.User, order *models.O
 	return nil
 }
 
-func (a *API) createLineItems(tx *gorm.DB, order *models.Order, items []models.LineItem) *HTTPError {
+func (a *API) createLineItems(ctx context.Context, tx *gorm.DB, order *models.Order, items []*OrderLineItem) *HTTPError {
+	sem := make(chan int, MaxConcurrentLookups)
+	var wg sync.WaitGroup
+	sharedErr := verificationError{}
 	for _, item := range items {
-		item.ID = 0 // Making sure you can't set this via params
-		item.OrderID = order.ID
+		lineItem := &models.LineItem{SKU: item.SKU, Quantity: item.Quantity, Path: item.Path, OrderID: order.ID}
+		order.LineItems = append(order.LineItems, lineItem)
+		sem <- 1
+		wg.Add(1)
+		go func(item *models.LineItem) {
+			// Stop doing any work if there's already an error
+			if sharedErr.err != nil {
+				<-sem
+				wg.Done()
+				return
+			}
+
+			if err := a.processLineItem(ctx, order, item); err != nil {
+				sharedErr.setError(err)
+			}
+			wg.Done()
+			<-sem
+		}(lineItem)
+	}
+	wg.Wait()
+
+	if sharedErr.err != nil {
+		tx.Rollback()
+		return &HTTPError{Code: 500, Message: fmt.Sprintf("Error processing line item: %v", sharedErr.err)}
+	}
+
+	for _, item := range order.LineItems {
 		order.SubTotal = order.SubTotal + item.Price*item.Quantity
 		if err := tx.Create(&item).Error; err != nil {
 			tx.Rollback()
 			return &HTTPError{Code: 500, Message: fmt.Sprintf("Error creating line item: %v", err)}
 		}
 	}
-	order.Total = order.SubTotal
+
 	return nil
 }
 
@@ -206,4 +253,30 @@ func (a *API) processAddress(tx *gorm.DB, order *models.Order, address *models.A
 		}
 	}
 	return address.ID, nil
+}
+
+func (a *API) processLineItem(ctx context.Context, order *models.Order, item *models.LineItem) error {
+	config := getConfig(ctx)
+	resp, err := a.httpClient.Get(config.SiteURL + item.Path)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	doc, err := goquery.NewDocumentFromResponse(resp)
+	if err != nil {
+		return err
+	}
+
+	metaTag := doc.Find("#gocommerce-product").First()
+	if metaTag.Length() == 0 {
+		return fmt.Errorf("No script tag with id gocommerce-product tag found for '%v'", item.Title)
+	}
+	meta := &models.LineItemMetadata{}
+	err = json.Unmarshal([]byte(metaTag.Text()), meta)
+	if err != nil {
+		return err
+	}
+
+	return item.Process(order, meta)
 }

--- a/config.example.json
+++ b/config.example.json
@@ -16,20 +16,15 @@
     "port": 587,
     "user": "test@example.com",
     "pass": "super-secret-password",
-    "template_folder": "/mail_templates",
-    "member_folder": "/users",
     "admin_email": "admin@example.com",
     "mail_subjects": {
-      "confirmation": "Welcome to Authlify!",
-      "recovery": "Reset your Authlify password!"
+      "confirmation": "Thank you for your order!"
     }
   },
   "payments": {
     "stripe": {
-
+      "secret_key": "Your secret key"
     },
-    "paypal": {
-
-    }
+    "paypal": {}
   }
 }

--- a/models/line_item.go
+++ b/models/line_item.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"strconv"
+	"time"
+)
 
 type LineItem struct {
 	ID      int64  `json:"id"`
@@ -8,7 +11,9 @@ type LineItem struct {
 
 	Title       string `json:"title"`
 	SKU         string `json:"sku"`
+	Type        string `json:"type"`
 	Description string `json:"description"`
+	VAT         uint64 `json:"vat"`
 
 	Path string `json:"path"`
 
@@ -17,4 +22,45 @@ type LineItem struct {
 
 	CreatedAt time.Time  `json:"-"`
 	DeletedAt *time.Time `json:"-"`
+}
+
+type PriceMetadata struct {
+	Amount   string `json:"amount"`
+	Currency string `json:"currency"`
+	VAT      string `json:"vat"`
+}
+
+type LineItemMetadata struct {
+	Sku         string          `json:"sku"`
+	Title       string          `json:"title"`
+	Description string          `json:"description"`
+	VAT         uint64          `json:"vat"`
+	Prices      []PriceMetadata `json:"prices"`
+	Type        string          `json:"type"`
+}
+
+func (i *LineItem) Process(order *Order, meta *LineItemMetadata) error {
+	i.SKU = meta.Sku
+	i.Title = meta.Title
+	i.Description = meta.Description
+	i.VAT = meta.VAT
+	i.Type = meta.Type
+
+	return i.calculatePrice(meta.Prices, order.Currency)
+}
+
+func (i *LineItem) calculatePrice(prices []PriceMetadata, currency string) error {
+	for _, price := range prices {
+		if price.Currency == currency {
+			amount, err := strconv.ParseFloat(price.Amount, 64)
+			if err != nil {
+				return err
+			}
+			cents := uint64(amount * 100)
+			if i.Price == 0 || cents < i.Price {
+				i.Price = cents
+			}
+		}
+	}
+	return nil
 }

--- a/models/order.go
+++ b/models/order.go
@@ -1,8 +1,11 @@
 package models
 
 import (
+	"encoding/json"
+	"math"
 	"time"
 
+	"github.com/jinzhu/gorm"
 	"github.com/pborman/uuid"
 )
 
@@ -18,8 +21,9 @@ type Order struct {
 
 	Email string `json:"email"`
 
-	LineItems []LineItem `json:"line_items"`
+	LineItems []*LineItem `json:"line_items"`
 
+	Currency string `json:"currency"`
 	Taxes    uint64 `json:"taxes"`
 	Shipping uint64 `json:"shipping"`
 	SubTotal uint64 `json:"subtotal"`
@@ -29,8 +33,8 @@ type Order struct {
 	FulfillmentState string `json:"fulfillment_state"`
 	State            string `json:"state"`
 
-	Transactions []Transaction `json:"transactions"`
-	Notes        []OrderNote   `json:"notes"`
+	Transactions []*Transaction `json:"transactions"`
+	Notes        []*OrderNote   `json:"notes"`
 
 	ShippingAddress   Address `json:"shipping_address",gorm:"ForeignKey:ShippingAddressID"`
 	ShippingAddressID string
@@ -38,19 +42,180 @@ type Order struct {
 	BillingAddress   Address `json:"billing_address",gorm:"ForeignKey:BillingAddressID"`
 	BillingAddressID string
 
+	Data []Data `json:"-"`
+
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`
 	DeletedAt *time.Time `json:"-",sql:"index"`
 }
 
-func NewOrder(sessionID, email string) *Order {
+// NUMBER|STRING|BOOL are the different types supported in custom data for orders
+const (
+	NUMBER = iota
+	STRING
+	BOOL
+)
+
+// Data is the custom data on an Order
+type Data struct {
+	OrderID string `gorm:"primary_key"`
+	Key     string `gorm:"primary_key"`
+
+	Type int
+
+	NumericValue float64
+	StringValue  string
+	BoolValue    bool
+}
+
+// Value returns the value of the data field
+func (d *Data) Value() interface{} {
+	switch d.Type {
+	case STRING:
+		return d.StringValue
+	case NUMBER:
+		return d.NumericValue
+	case BOOL:
+		return d.BoolValue
+	}
+	return nil
+}
+
+// InvalidDataType is an error returned when trying to set an invalid datatype for
+// a user data key
+type InvalidDataType struct {
+	Key string
+}
+
+func (i *InvalidDataType) Error() string {
+	return "Invalid datatype for data field " + i.Key + " only strings, numbers and bools allowed"
+}
+
+func orderDataToMap(data []Data) map[string]interface{} {
+	result := map[string]interface{}{}
+	for _, field := range data {
+		switch field.Type {
+		case NUMBER:
+			result[field.Key] = field.NumericValue
+		case STRING:
+			result[field.Key] = field.StringValue
+		case BOOL:
+			result[field.Key] = field.BoolValue
+		}
+	}
+	return result
+}
+
+// MarshalJSON is a custom JSON marshaller for Users
+func (o *Order) MarshalJSON() ([]byte, error) {
+	type Alias Order
+	return json.Marshal(&struct {
+		*Alias
+		Data map[string]interface{} `json:"data"`
+	}{
+		Alias: (*Alias)(o),
+		Data:  orderDataToMap(o.Data),
+	})
+}
+
+func NewOrder(sessionID, email, currency string) *Order {
 	order := &Order{
 		ID:        uuid.NewRandom().String(),
 		SessionID: sessionID,
 		Email:     email,
+		Currency:  currency,
 	}
 	order.PaymentState = PendingState
 	order.FulfillmentState = PendingState
 	order.State = PendingState
 	return order
+}
+
+// UpdateOrderData updates all user data from a map of updates
+func (o *Order) UpdateOrderData(tx *gorm.DB, updates *map[string]interface{}) error {
+	for key, value := range *updates {
+		data := &Data{}
+		result := tx.First(data, "order_id = ? and key = ?", o.ID, key)
+		data.OrderID = o.ID
+		data.Key = key
+		if result.Error != nil && !result.RecordNotFound() {
+			tx.Rollback()
+			return result.Error
+		}
+		if value == nil {
+			tx.Delete(data)
+			continue
+		}
+		switch v := value.(type) {
+		case string:
+			data.StringValue = v
+			data.Type = STRING
+		case float64:
+			data.NumericValue = v
+			data.Type = NUMBER
+		case bool:
+			data.BoolValue = v
+			data.Type = BOOL
+		default:
+			tx.Rollback()
+			return &InvalidDataType{key}
+		}
+		if result.RecordNotFound() {
+			tx.Create(data)
+		} else {
+			tx.Save(data)
+		}
+	}
+	return nil
+}
+
+func (o *Order) CalculateTotal(settings *SiteSettings) {
+	// Calculate taxes/shipping here
+	var taxes uint64
+	for _, item := range o.LineItems {
+		taxes += taxFor(item, settings.Taxes, o.BillingAddress.Country)
+	}
+
+	o.Total = o.SubTotal + taxes
+}
+
+func inList(list []string, candidate string) bool {
+	for _, item := range list {
+		if item == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func taxFor(item *LineItem, taxes []*Tax, country string) uint64 {
+	if item.VAT != 0 {
+		return item.Price * item.Quantity * (item.VAT / 100)
+	}
+	if len(taxes) > 0 && country != "" {
+		for _, tax := range taxes {
+			if inList(tax.ProductTypes, item.Type) && inList(tax.Countries, country) {
+				result := float64(item.Price) * float64(item.Quantity) * (float64(tax.Percentage) / 100)
+				return uint64(rint(result))
+			}
+		}
+	}
+	return 0
+}
+
+// Nopes - no `round` method in go
+// See https://gist.github.com/siddontang/1806573b9a8574989ccb
+func rint(x float64) float64 {
+	v, frac := math.Modf(x)
+	if x > 0.0 {
+		if frac > 0.5 || (frac == 0.5 && uint64(v)%2 != 0) {
+			v += 1.0
+		}
+	} else {
+		if frac < -0.5 || (frac == -0.5 && uint64(v)%2 != 0) {
+			v -= 1.0
+		}
+	}
+
+	return v
 }

--- a/models/site_settings.go
+++ b/models/site_settings.go
@@ -1,0 +1,11 @@
+package models
+
+type SiteSettings struct {
+	Taxes []Tax `json:"taxes"`
+}
+
+type Tax struct {
+	Percentage   int      `json:"percentage"`
+	ProductTypes []string `json:"product_types"`
+	Countries    []string `json:"countries"`
+}

--- a/models/site_settings.go
+++ b/models/site_settings.go
@@ -1,11 +1,11 @@
 package models
 
 type SiteSettings struct {
-	Taxes []Tax `json:"taxes"`
+	Taxes []*Tax `json:"taxes"`
 }
 
 type Tax struct {
-	Percentage   int      `json:"percentage"`
+	Percentage   uint64   `json:"percentage"`
 	ProductTypes []string `json:"product_types"`
 	Countries    []string `json:"countries"`
 }


### PR DESCRIPTION
This includes some API changes. Mainly the line items only
require a Path and a Quantity and are verified when added.

Gocommerce will now check the site for a /gocommerce/settings.json
file that can currently set VAT rules based on countries/product types.

An amount must be included when triggering a payment, to verify that
the tax calculations the user has been shown in the UI matches what we
are actually going to charge.