### PR TITLE
Rename project to Netlify Commerce.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM calavera/go-glide:v0.12.2
 
-ADD . /go/src/github.com/netlify/gocommerce
+ADD . /go/src/github.com/netlify/commerce
 
-RUN cd /go/src/github.com/netlify/gocommerce && make deps build && mv gocommerce /usr/local/bin/
+RUN cd /go/src/github.com/netlify/commerce && make deps build && mv commerce /usr/local/bin/
 
-CMD ["gocommerce"]
+CMD ["commerce"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2016 Netlify <hello@netlify.com>
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
-# Gocommerce
+# Netlify Commerce
 
 A small go based API for static e-commerce sites.
 
 It handles orders and payments. Integrates with Stripe for payments and will support
 international pricing and VAT verification.
 
+Netlify Commerce is released under the [MIT License](LICENSE).
+Please make sure you understand its [implications and guarantees](https://writing.kemitchell.com/2016/09/21/MIT-License-Line-by-Line.html).
+
 ## Setting up
 
 See [the example configuration](config.example.json) for an example of how to configure
-Gocommerce.
+Netlify Ccommerce.
 
-The most important setting is the `site_url`. Gocommerce is always tied to a website,
+The most important setting is the `site_url`. Netlify Ccommerce is always tied to a website,
 and will use the site URL to verify product prices, offers, and settings for countries,
 product types and VAT rules.
 
-Gocommerce will also look for email templates within a designated site folder and use
+Netlify Commerce will also look for email templates within a designated site folder and use
 the site URL to construct links to order history.
 
 Create a `config.json` file based on `config.example.json` - You must set the `site_url`
@@ -22,13 +25,13 @@ and the `stripe_key` as a minimum.
 
 ### What your static site must support
 
-Each product you want to sell from your static site must have unique URL where Gocommerce
+Each product you want to sell from your static site must have unique URL where Netlify Commerce
 can find the meta data needed for calculating pricing and taxes in order to verify that
 the order is legitimate before using Stripe to charge the client.
 
 The metadata can be anywhere on the page, and goes in a script tag in this format:
 
-<script id="gocommerce-product" type="application/json">
+<script id="netlify-commerce-product" type="application/json">
 {"sku": "my-product", "title": "My Product", "prices": [{"amount": "49.99"}], "type": "ebook"}
 </script>
 
@@ -36,20 +39,20 @@ The minimum required is the SKU, title and at least one "price". Default currenc
 
 ### Mail templates (Not implemented yet)
 
-Gocommerce will look for mail templates inside `https://yoursite.com/gocommerce/emails/`
+Netlify Commerce will look for mail templates inside `https://yoursite.com/netlify-commerce/emails/`
 when sending mails to users or administrators.
 
 Right now the mail templates are:
 
-* **Order Confirmation** `gocommerce/emails/confirmation.html`
+* **Order Confirmation** `netlify-commerce/emails/confirmation.html`
 
 ### VAT, Countries and Regions
 
-Gocommerce will regularly check for a file called `https://yoursite.com/gocommerce/settings.json`
+Netlify Commerce will regularly check for a file called `https://yoursite.com/netlify-commerce/settings.json`
 
 This file should have settings with rules for VAT or currency regions.
 
-This file is not required for gocommerce to work, but will enable support for various advanced
+This file is not required for Netlify Commerce to work, but will enable support for various advanced
 features. Currently it enables VAT calculations on a per country/product type basic.
 
 The reason we make you include the file in the static site, is that you'll need to do the same
@@ -74,10 +77,10 @@ Here's an example settings file:
 ```
 
 Based on these rules, if an order includes a product with "type" set to "ebook" in the product metadata
-on the site and the users billing Address is set to "Austria", Gocommerce will verify that a 20 percentage
+on the site and the users billing Address is set to "Austria", Netlify Commerce will verify that a 20 percentage
 tax has been included in that product.
 
 
 # JavaScript Client Library
 
-The easiest way to use Gocommerce is with [gocommerce-js](https://github.com/netlify/gocommerce-js).
+The easiest way to use Netlify Commerce is with [gocommerce-js](https://github.com/netlify/gocommerce-js).

--- a/api/api.go
+++ b/api/api.go
@@ -8,11 +8,11 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/guregu/kami"
 	"github.com/jinzhu/gorm"
-	"github.com/netlify/gocommerce/conf"
-	"github.com/netlify/gocommerce/mailer"
+	"github.com/netlify/commerce/conf"
+	"github.com/netlify/commerce/mailer"
 	"github.com/rs/cors"
 )
 

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/dgrijalva/jwt-go"
-	"github.com/netlify/gocommerce/conf"
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/netlify/commerce/conf"
 	"golang.org/x/net/context"
 )
 

--- a/api/index.go
+++ b/api/index.go
@@ -7,8 +7,8 @@ import (
 )
 
 const description = `{
-  "name": "GoCommerce",
-  "description": "GoCommerce is a flexible Ecommerce API for JAM sites"
+  "name": "Netlify Commerce",
+  "description": "Netlify Commerce is a flexible Ecommerce API for JAMStack sites"
 }`
 
 // Index endpoint

--- a/api/order.go
+++ b/api/order.go
@@ -7,11 +7,11 @@ import (
 	"sync"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/guregu/kami"
 	"github.com/jinzhu/gorm"
 	"github.com/mattes/vat"
-	"github.com/netlify/gocommerce/models"
+	"github.com/netlify/commerce/models"
 	"github.com/pborman/uuid"
 
 	"golang.org/x/net/context"
@@ -286,9 +286,13 @@ func (a *API) processLineItem(ctx context.Context, order *models.Order, item *mo
 		return err
 	}
 
-	metaTag := doc.Find("#gocommerce-product").First()
+	metaTag := doc.Find("#netlify-commerce-product").First()
 	if metaTag.Length() == 0 {
-		return fmt.Errorf("No script tag with id gocommerce-product tag found for '%v'", item.Title)
+		metaTag = doc.Find("#gocommerce-product").First() // Keep the code backwards compatible
+
+		if metaTag.Length() == 0 {
+			return fmt.Errorf("No script tag with id netlify-commerce-product tag found for '%v'", item.Title)
+		}
 	}
 	meta := &models.LineItemMetadata{}
 	err = json.Unmarshal([]byte(metaTag.Text()), meta)

--- a/api/payments.go
+++ b/api/payments.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"github.com/guregu/kami"
-	"github.com/netlify/gocommerce/models"
-	"github.com/stripe/stripe-go"
+	"github.com/netlify/commerce/models"
+	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/charge"
 	"golang.org/x/net/context"
 )
@@ -150,7 +150,7 @@ func (a *API) verifyAmount(ctx context.Context, order *models.Order, amount uint
 	config := getConfig(ctx)
 
 	settings := &models.SiteSettings{}
-	resp, err := a.httpClient.Get(config.SiteURL + "/gocommerce/settings.json")
+	resp, err := a.httpClient.Get(config.SiteURL + "/netlify-commerce/settings.json")
 	if err != nil {
 		return err
 	}

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -5,17 +5,17 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
-	"github.com/stripe/stripe-go"
+	stripe "github.com/stripe/stripe-go"
 
-	"github.com/netlify/gocommerce/api"
-	"github.com/netlify/gocommerce/conf"
-	"github.com/netlify/gocommerce/mailer"
-	"github.com/netlify/gocommerce/models"
+	"github.com/netlify/commerce/api"
+	"github.com/netlify/commerce/conf"
+	"github.com/netlify/commerce/mailer"
+	"github.com/netlify/commerce/models"
 )
 
 // RootCmd will run the log streamer
 var RootCmd = cobra.Command{
-	Use:  "gocommerce",
+	Use:  "commerce",
 	Long: "A service that will validate restful transactions and send them to stripe.",
 	Run: func(cmd *cobra.Command, args []string) {
 		configFile, err := cmd.PersistentFlags().GetString("config")

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -51,11 +51,12 @@ func Load(configFile string) (*Configuration, error) {
 		viper.SetConfigFile(configFile)
 	} else {
 		viper.SetConfigName("config")
-		viper.AddConfigPath("./")                 // ./config.[json | toml]
-		viper.AddConfigPath("$HOME/.gocommerce/") // ~/.gocommerce/config.[json | toml]
+		viper.AddConfigPath("./")                       // ./config.[json | toml]
+		viper.AddConfigPath("$HOME/.gocommerce/")       // ~/.gocommerce/config.[json | toml] // Keep the configuration backwards compatible
+		viper.AddConfigPath("$HOME/.netlify-commerce/") // ~/.netlify-commerce/config.[json | toml]
 	}
 
-	viper.SetEnvPrefix("GCOM")
+	viper.SetEnvPrefix("NETLIFY_COMMERCE")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fb141f21a878c9c4a8cb718ec3e6a2d27e3c6f2509b02c693aff7c99edb8d487
-updated: 2016-09-15T15:15:38.738499961-07:00
+hash: 6ac64190758f83c55eab12b728d36229ebdb6575b906b90dcd7c7c51476cea7c
+updated: 2016-09-22T14:55:43.238899847-07:00
 imports:
 - name: github.com/andybalholm/cascadia
   version: 1c31af6f6c1a7b101ed05aacc7d8a738b43ae86e

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/netlify/gocommerce
+package: github.com/netlify/commerce
 import:
 - package: github.com/PuerkitoBio/goquery
 - package: github.com/dgrijalva/jwt-go

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -3,9 +3,10 @@ package mailer
 import (
 	"fmt"
 
-	"github.com/netlify/gocommerce/conf"
-	"github.com/netlify/gocommerce/models"
-	"gopkg.in/gomail.v2"
+	gomail "gopkg.in/gomail.v2"
+
+	"github.com/netlify/commerce/conf"
+	"github.com/netlify/commerce/models"
 )
 
 // Mailer will send mail and use templates from the site for easy mail styling

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/netlify/gocommerce/cmd"
+	"github.com/netlify/commerce/cmd"
 )
 
 func main() {

--- a/models/connection.go
+++ b/models/connection.go
@@ -5,7 +5,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/netlify/gocommerce/conf"
+	"github.com/netlify/commerce/conf"
 
 	"github.com/jinzhu/gorm"
 )


### PR DESCRIPTION
Making the project more consistent with our branding.

- Add LICENSE file and links.
- Handle some backwards compatible settings to make migration easier.

Signed-off-by: David Calavera <david.calavera@gmail.com>