### PR TITLE
Add temporary redirect to repo

### DIFF
--- a/www/site/static/_redirects
+++ b/www/site/static/_redirects
@@ -1,0 +1,1 @@
+/* http://github.com/netlify/gocommerce 302!


### PR DESCRIPTION
**- Summary**
The docs site isn't ready, but we want to use its domain in articles now.

**- Test plan**
I tested in the Netlify Playground

**- Description for the changelog**
Temporary redirect to GitHub repo
