### PR TITLE
Support member discounts and fixed coupon amounts

### DIFF
--- a/api/order.go
+++ b/api/order.go
@@ -767,6 +767,7 @@ func (a *API) processAddress(tx *gorm.DB, order *models.Order, name string, addr
 
 func (a *API) processLineItem(ctx context.Context, order *models.Order, item *models.LineItem, orderItem *OrderLineItem) error {
 	config := getConfig(ctx)
+	jwtClaims := getClaimsAsMap(ctx)
 	resp, err := a.httpClient.Get(config.SiteURL + item.Path)
 	if err != nil {
 		return err
@@ -810,7 +811,7 @@ func (a *API) processLineItem(ctx context.Context, order *models.Order, item *mo
 				})
 			}
 
-			return item.Process(order, meta)
+			return item.Process(jwtClaims, order, meta)
 		}
 	}
 

--- a/api/order.go
+++ b/api/order.go
@@ -708,7 +708,7 @@ func (a *API) createLineItems(ctx context.Context, tx *gorm.DB, order *models.Or
 		return &HTTPError{Code: 500, Message: err.Error()}
 	}
 
-	order.CalculateTotal(settings)
+	order.CalculateTotal(settings, getClaimsAsMap(ctx))
 
 	return nil
 }

--- a/api/user.go
+++ b/api/user.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"reflect"
@@ -50,6 +51,10 @@ func (a *API) UserList(ctx context.Context, w http.ResponseWriter, r *http.Reque
 
 	offset, limit, err := paginate(w, r, query.Model(&models.User{}))
 	if err != nil {
+		if err == sql.ErrNoRows {
+			sendJSON(w, 200, []string{})
+			return
+		}
 		badRequestError(w, "Bad Pagination Parameters: %v", err)
 		return
 	}

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -169,7 +169,7 @@ func loadTestData(db *gorm.DB) {
 
 	firstOrder.ID = "first-order"
 	firstOrder.LineItems = []*models.LineItem{&firstLineItem}
-	firstOrder.CalculateTotal(&calculator.Settings{})
+	firstOrder.CalculateTotal(&calculator.Settings{}, nil)
 	firstOrder.BillingAddress = testAddress
 	firstOrder.ShippingAddress = testAddress
 	firstOrder.User = &testUser
@@ -179,7 +179,7 @@ func loadTestData(db *gorm.DB) {
 
 	secondOrder.ID = "second-order"
 	secondOrder.LineItems = []*models.LineItem{&secondLineItem1, &secondLineItem2}
-	secondOrder.CalculateTotal(&calculator.Settings{})
+	secondOrder.CalculateTotal(&calculator.Settings{}, nil)
 	secondOrder.BillingAddress = testAddress
 	secondOrder.ShippingAddress = testAddress
 	secondOrder.User = &testUser

--- a/calculator/calculator_test.go
+++ b/calculator/calculator_test.go
@@ -57,7 +57,7 @@ func (c *TestCoupon) PercentageDiscount() uint64 {
 	return c.percentage
 }
 
-func (c *TestCoupon) FixedDiscount() uint64 {
+func (c *TestCoupon) FixedDiscount(currency string) uint64 {
 	return c.fixed
 }
 

--- a/claims/claims.go
+++ b/claims/claims.go
@@ -1,0 +1,37 @@
+package claims
+
+import "strings"
+
+// HasClaims is used to determine if a set of userClaims matches the requiredClaims
+func HasClaims(userClaims map[string]interface{}, requiredClaims map[string]string) bool {
+	if requiredClaims == nil {
+		return true
+	}
+	if userClaims == nil {
+		return false
+	}
+
+	for key, value := range requiredClaims {
+		parts := strings.Split(key, ".")
+		obj := userClaims
+		for i, part := range parts {
+			newObj, hasObj := obj[part]
+			if !hasObj {
+				return false
+			}
+			if i+1 == len(parts) {
+				str, isString := newObj.(string)
+				if !isString {
+					return false
+				}
+				return str == value
+			}
+			obj, hasObj = newObj.(map[string]interface{})
+			if !hasObj {
+				return false
+			}
+
+		}
+	}
+	return false
+}

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -101,8 +101,11 @@ func Load(configFile string) (*Configuration, error) {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 
-	if err := viper.ReadInConfig(); err != nil && !os.IsNotExist(err) {
-		return nil, errors.Wrap(err, "reading configuration from files")
+	if err := viper.ReadInConfig(); err != nil {
+		_, ok := err.(viper.ConfigFileNotFoundError)
+		if !ok {
+			return nil, errors.Wrap(err, "reading configuration from files")
+		}
 	}
 
 	config := new(Configuration)

--- a/models/coupon.go
+++ b/models/coupon.go
@@ -2,14 +2,19 @@ package models
 
 import "time"
 
+type FixedAmount struct {
+	Amount   uint64 `json:"amount"`
+	Currency string `json:"currency"`
+}
+
 type Coupon struct {
 	Code string `json:"code"`
 
 	StartDate *time.Time `json:"start_date,omitempty"`
 	EndDate   *time.Time `json:"end_date,omitempty"`
 
-	Percentage uint64 `json:"percentage,omitempty"`
-	Amount uint64 `json:"amount,omitempty"`
+	Percentage  uint64         `json:"percentage,omitempty"`
+	FixedAmount []*FixedAmount `json:"fixed,omitempty"`
 
 	ProductTypes []string               `json:"product_types,omitempty"`
 	Claims       map[string]interface{} `json:"claims,omitempty"`
@@ -51,7 +56,14 @@ func (c *Coupon) ValidForPrice(currency string, price uint64) bool {
 func (c *Coupon) PercentageDiscount() uint64 {
 	return c.Percentage
 }
-func (c *Coupon) FixedDiscount() uint64 {
-	// TODO: Support for fixed amount discoutns
+func (c *Coupon) FixedDiscount(currency string) uint64 {
+	if c.FixedAmount != nil {
+		for _, discount := range c.FixedAmount {
+			if discount.Currency == currency {
+				return discount.Amount
+			}
+		}
+	}
+
 	return 0
 }

--- a/models/coupon.go
+++ b/models/coupon.go
@@ -9,6 +9,7 @@ type Coupon struct {
 	EndDate   *time.Time `json:"end_date,omitempty"`
 
 	Percentage uint64 `json:"percentage,omitempty"`
+	Amount uint64 `json:"amount,omitempty"`
 
 	ProductTypes []string               `json:"product_types,omitempty"`
 	Claims       map[string]interface{} `json:"claims,omitempty"`

--- a/models/order.go
+++ b/models/order.go
@@ -127,13 +127,13 @@ func NewOrder(sessionID, email, currency string) *Order {
 	return order
 }
 
-func (o *Order) CalculateTotal(settings *calculator.Settings) {
+func (o *Order) CalculateTotal(settings *calculator.Settings, claims map[string]interface{}) {
 	items := make([]calculator.Item, len(o.LineItems))
 	for i, item := range o.LineItems {
 		items[i] = item
 	}
 
-	price := calculator.CalculatePrice(settings, o.ShippingAddress.Country, o.Currency, o.Coupon, items)
+	price := calculator.CalculatePrice(settings, claims, o.ShippingAddress.Country, o.Currency, o.Coupon, items)
 
 	o.SubTotal = price.Subtotal
 	o.Taxes = price.Taxes


### PR DESCRIPTION
This adds support to defining member discounts in the gocommerce settings files.

Coupons (and member discounts) also gets a fixed discount option that sets the discount to a specific amount