### PR TITLE
Add route filters for users and orders search

### DIFF
--- a/api/order.go
+++ b/api/order.go
@@ -200,6 +200,8 @@ func (a *API) ResendOrderReceipt(ctx context.Context, w http.ResponseWriter, r *
 //  - fullfilment_state=pending   - only orders pending shipping
 //  - payment_state=pending       - only payd orders
 //  - type=book  - filter on product type
+//  - email
+//  - item
 
 func (a *API) OrderList(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	log := getLogger(ctx)

--- a/api/order.go
+++ b/api/order.go
@@ -201,7 +201,7 @@ func (a *API) ResendOrderReceipt(ctx context.Context, w http.ResponseWriter, r *
 //  - payment_state=pending       - only payd orders
 //  - type=book  - filter on product type
 //  - email
-//  - item
+//  - items
 
 func (a *API) OrderList(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	log := getLogger(ctx)

--- a/api/order_test.go
+++ b/api/order_test.go
@@ -159,6 +159,51 @@ func TestOrderQueryForAllOrdersAsTheUser(t *testing.T) {
 	}
 }
 
+func TestOrderQueryEmailFilterAsTheUser(t *testing.T) {
+	db, config := db(t)
+
+	ctx := testContext(testToken(testUser.ID, testUser.Email), config, false)
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "https://not-real?email=bruce", nil)
+
+	api := NewAPI(config, db, nil, nil, nil)
+	api.OrderList(ctx, recorder, req)
+
+	orders := []models.Order{}
+	extractPayload(t, 200, recorder, &orders)
+	assert.Equal(t, 2, len(orders))
+}
+
+func TestEmptyOrderQueryEmailFilterAsTheUser(t *testing.T) {
+	db, config := db(t)
+
+	ctx := testContext(testToken(testUser.ID, testUser.Email), config, false)
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "https://not-real?email=gmail.com", nil)
+
+	api := NewAPI(config, db, nil, nil, nil)
+	api.OrderList(ctx, recorder, req)
+
+	orders := []models.Order{}
+	extractPayload(t, 200, recorder, &orders)
+	assert.Equal(t, 0, len(orders))
+}
+
+func TestOrderQueryItemFilterAsTheUser(t *testing.T) {
+	db, config := db(t)
+
+	ctx := testContext(testToken(testUser.ID, testUser.Email), config, false)
+	recorder := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "https://not-real?items=batwing", nil)
+
+	api := NewAPI(config, db, nil, nil, nil)
+	api.OrderList(ctx, recorder, req)
+
+	orders := []models.Order{}
+	extractPayload(t, 200, recorder, &orders)
+	assert.Equal(t, 1, len(orders))
+}
+
 func TestOrderQueryForAllOrdersAsAdmin(t *testing.T) {
 	db, config := db(t)
 
@@ -188,6 +233,7 @@ func TestOrderQueryForAllOrdersAsAdmin(t *testing.T) {
 		}
 	}
 }
+
 
 func TestOrderQueryForOwnOrdersAsStranger(t *testing.T) {
 	db, config := db(t)

--- a/api/params.go
+++ b/api/params.go
@@ -121,6 +121,14 @@ func parseOrderParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {
 		query = query.Where(models.Order{}.TableName()+".email LIKE ?", "%"+email+"%")
 	}
 
+	if items := params.Get("items"); items != "" {
+		lineItemTable := models.LineItem{}.TableName()
+		orderTable := models.Order{}.TableName()
+		statement := "JOIN " + lineItemTable + " as line_item on line_item.order_id = " +
+			orderTable + ".id AND line_item.title LIKE ?"
+		query = query.Joins(statement, "%"+items+"%")
+	}
+
 	return parseTimeQueryParams(query, params)
 }
 

--- a/api/params.go
+++ b/api/params.go
@@ -117,6 +117,10 @@ func parseOrderParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {
 		query = query.Order("created_at desc")
 	}
 
+	if email := params.Get("email"); email != "" {
+		query = query.Where(models.Order{}.TableName()+".email LIKE ?", "%"+email+"%")
+	}
+
 	return parseTimeQueryParams(query, params)
 }
 

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -40,7 +40,7 @@ func TestUsersQueryForAllUsersWithParams(t *testing.T) {
 
 	ctx := testContext(testToken("magical-unicorn", ""), config, true)
 
-	req, _ := http.NewRequest("GET", "http://junk?email=twoface@dc.com", nil)
+	req, _ := http.NewRequest("GET", "http://junk?email=dc.com", nil)
 	recorder := httptest.NewRecorder()
 	NewAPI(config, db, nil, nil, nil).UserList(ctx, recorder, req)
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
   version: v1.0
 - package: github.com/lib/pq
 - package: github.com/mattn/go-sqlite3
-  version: v1.1.0
+  version: v1.2.0
 - package: github.com/pborman/uuid
   version: v1.0
 - package: github.com/rs/cors


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gocommerce/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

This PR adds a tweak to the email filter for the UserList endpoint and adds an email and items filter to the OrderList endpoint.  The purpose of the changes is to enable some basic search functionality in the [gocommerce-admin](https://github.com/netlify/gocommerce-admin/pull/2).

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

I wrote some tests similar to the ones that existed that test these code paths.

**- Description for the changelog**

- Changed Email filter on the UserList endpoint is now a partial match filter.
- Added Email and Items filter to OrderList endpoint.  Both will return partial matches.  The Items filter matches against the LineItems title field.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

![ourhero](https://cloud.githubusercontent.com/assets/166301/25790011/5bcc1eb0-336a-11e7-8dc8-863933af6d72.jpg)
