### PR TITLE
[Dockerfile] Fix build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM calavera/go-glide:v0.12.2
 
 ADD . /go/src/github.com/netlify/gocommerce
 
-RUN useradd -m netlify && cd /go/src/github.com/netlify/gocommerce && make deps build && mv gocommerce /usr/local/bin/
+RUN useradd -m netlify && cd /go/src/github.com/netlify/gocommerce && make deps build_linux && mv gocommerce /usr/local/bin/
 
 USER netlify
 CMD ["gocommerce"]


### PR DESCRIPTION
**- Summary**
Binary is not executable inside the Docker image

**- Test plan**
The binary is built for Darwin, not Linux
```
$ make image
[...]
Successfully built a7e7971f5351
$ docker run -ti a7e7971f5351
standard_init_linux.go:187: exec user process caused "exec format error"
```

**- Description for the changelog**
Fix the binary build inside the Docker image
