### PR TITLE
Add noop mailer to use if no mailer config present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 config.json
 gorm.db
 netlify-commerce
+gocommerce
 
 vendor/
 .idea

--- a/api/api.go
+++ b/api/api.go
@@ -33,7 +33,7 @@ type API struct {
 	db         *gorm.DB
 	paypal     *paypalsdk.Client
 	config     *conf.Configuration
-	mailer     *mailer.Mailer
+	mailer     mailer.Mailer
 	httpClient *http.Client
 	log        *logrus.Entry
 	assets     assetstores.Store
@@ -116,12 +116,12 @@ func (a *API) ListenAndServe(hostAndPort string) error {
 	return http.ListenAndServe(hostAndPort, a.handler)
 }
 
-func NewAPI(config *conf.Configuration, db *gorm.DB, paypal *paypalsdk.Client, mailer *mailer.Mailer, store assetstores.Store) *API {
+func NewAPI(config *conf.Configuration, db *gorm.DB, paypal *paypalsdk.Client, mailer mailer.Mailer, store assetstores.Store) *API {
 	return NewAPIWithVersion(config, db, paypal, mailer, store, defaultVersion)
 }
 
 // NewAPIWithVersion instantiates a new REST API
-func NewAPIWithVersion(config *conf.Configuration, db *gorm.DB, paypal *paypalsdk.Client, mailer *mailer.Mailer, assets assetstores.Store, version string) *API {
+func NewAPIWithVersion(config *conf.Configuration, db *gorm.DB, paypal *paypalsdk.Client, mailer mailer.Mailer, assets assetstores.Store, version string) *API {
 	api := &API{
 		log:        logrus.WithField("component", "api"),
 		config:     config,

--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -1,0 +1,23 @@
+package mailer
+
+import (
+	"testing"
+
+	"github.com/netlify/gocommerce/conf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoopMailer(t *testing.T) {
+	conf := &conf.Configuration{}
+	m := NewMailer(conf)
+	assert.IsType(t, &noopMailer{}, m)
+}
+
+func TestTemplateMailer(t *testing.T) {
+	conf := &conf.Configuration{}
+	conf.Mailer.AdminEmail = "test@example.com"
+	conf.Mailer.Host = "localhost"
+	conf.Mailer.Port = 25
+	m := NewMailer(conf)
+	assert.IsType(t, &mailer{}, m)
+}

--- a/mailer/noop.go
+++ b/mailer/noop.go
@@ -1,0 +1,16 @@
+package mailer
+
+import "github.com/netlify/gocommerce/models"
+
+type noopMailer struct{}
+
+func newNoopMailer() Mailer {
+	return &noopMailer{}
+}
+
+func (m *noopMailer) OrderConfirmationMail(transaction *models.Transaction) error {
+	return nil
+}
+func (m *noopMailer) OrderReceivedMail(transaction *models.Transaction) error {
+	return nil
+}


### PR DESCRIPTION
Fixes #53

**- Summary**

This makes the mailer configuration optional instead of required. Emails can be handled by the payment provider, such as Stripe.

**- Test plan**

Automated tests added.

**- Description for the changelog**

If an invalid mailer config is provided, use a noop mailer instead of failing.



