### PR TITLE
Change paypal to be optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ gocommerce
 
 vendor/
 .idea
+.vscode
 *.iml
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ product types and VAT rules.
 GoCommerce will also look for email templates within a designated site folder and use
 the site URL to construct links to order history.
 
-Create a `config.json` file based on `config.example.json` - You must set the `site_url`,
-`stripe_key` and paypal `client_id` and `secret` as a minimum.  You can get paypal keys by
+Create a `config.json` file based on `config.example.json` - You must set the `site_url` and
+`stripe_key`. Optionally, you may set paypal `client_id` and `secret`. You can get paypal keys by
 creating an app at on the `REST API apps` section of the [paypal developer website](https://developer.paypal.com/developer/applications/).
 
 ### What your static site must support

--- a/api/api.go
+++ b/api/api.go
@@ -168,8 +168,10 @@ func NewAPIWithVersion(config *conf.Configuration, db *gorm.DB, paypal *paypalsd
 	mux.Get("/payments/:pay_id", api.PaymentView)
 	mux.Post("/payments/:pay_id/refund", api.PaymentRefund)
 
-	mux.Post("/paypal", api.PaypalCreatePayment)
-	mux.Get("/paypal/:payment_id", api.PaypalGetPayment)
+	if paypal != nil {
+		mux.Post("/paypal", api.PaypalCreatePayment)
+		mux.Get("/paypal/:payment_id", api.PaypalGetPayment)
+	}
 
 	mux.Get("/reports/sales", api.SalesReport)
 	mux.Get("/reports/products", api.ProductsReport)
@@ -214,7 +216,9 @@ func (a *API) populateContext(ctx context.Context, w http.ResponseWriter, r *htt
 	ctx = withLogger(ctx, log)
 	ctx = withConfig(ctx, a.config)
 	ctx = withStartTime(ctx, time.Now())
-	ctx = withPayer(ctx, PaypalChargerType, &paypalProvider{a.paypal})
+	if a.paypal != nil {
+		ctx = withPayer(ctx, PaypalChargerType, &paypalProvider{a.paypal})
+	}
 	ctx = withPayer(ctx, StripeChargerType, &stripeProvider{})
 	ctx = withCoupons(ctx, a.config)
 

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -122,6 +122,7 @@ func loadTestData(db *gorm.DB) {
 
 	firstOrder = models.NewOrder("session1", testUser.Email, "usd")
 	firstOrder.UserID = testUser.ID
+	firstOrder.PaymentProcessor = "stripe"
 	firstTransaction = models.NewTransaction(firstOrder)
 	firstTransaction.ProcessorID = "stripe"
 	firstTransaction.Amount = 100
@@ -140,7 +141,9 @@ func loadTestData(db *gorm.DB) {
 
 	secondOrder = models.NewOrder("session2", testUser.Email, "usd")
 	secondOrder.UserID = testUser.ID
+	secondOrder.PaymentProcessor = "paypal"
 	secondTransaction = models.NewTransaction(secondOrder)
+	secondTransaction.ProcessorID = "paypal"
 	secondLineItem1 = models.LineItem{
 		ID:          21,
 		OrderID:     secondOrder.ID,
@@ -183,6 +186,8 @@ func loadTestData(db *gorm.DB) {
 	secondOrder.BillingAddress = testAddress
 	secondOrder.ShippingAddress = testAddress
 	secondOrder.User = &testUser
+	secondTransaction.Amount = secondOrder.Total
+	secondTransaction.Status = models.PaidState
 	db.Create(&secondLineItem1)
 	db.Create(&secondLineItem2)
 	db.Create(secondTransaction)

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -34,24 +34,27 @@ func serve(config *conf.Configuration) {
 		logrus.Fatalf("Error opening database: %+v", err)
 	}
 
-	var ppEnv string
-	if config.Payment.Paypal.Env == "production" {
-		ppEnv = paypalsdk.APIBaseLive
-	} else {
-		ppEnv = paypalsdk.APIBaseSandBox
-	}
+	var paypal *paypalsdk.Client
+	if config.Payment.Paypal.ClientID != "" && config.Payment.Paypal.Secret != "" {
+		var ppEnv string
+		if config.Payment.Paypal.Env == "production" {
+			ppEnv = paypalsdk.APIBaseLive
+		} else {
+			ppEnv = paypalsdk.APIBaseSandBox
+		}
 
-	paypal, err := paypalsdk.NewClient(
-		config.Payment.Paypal.ClientID,
-		config.Payment.Paypal.Secret,
-		ppEnv,
-	)
-	if err != nil {
-		logrus.Fatalf("Error configuring paypal: %+v", err)
-	}
-	_, err = paypal.GetAccessToken()
-	if err != nil {
-		logrus.Fatalf("Error authorizing with paypal: %+v", err)
+		paypal, err = paypalsdk.NewClient(
+			config.Payment.Paypal.ClientID,
+			config.Payment.Paypal.Secret,
+			ppEnv,
+		)
+		if err != nil {
+			logrus.Fatalf("Error configuring paypal: %+v", err)
+		}
+		_, err = paypal.GetAccessToken()
+		if err != nil {
+			logrus.Fatalf("Error authorizing with paypal: %+v", err)
+		}
 	}
 
 	mailer := mailer.NewMailer(config)


### PR DESCRIPTION
**- Summary**

PayPal should be an optional, additional payment processor.

**- Test plan**

Automated tests need to be added around payment creation. I added some additional logic and a test to ensure you do not attempt a refund of a PayPal transaction (since that is not implemented yet #58). 

**- Description for the changelog**

Change PayPal to be an optional, additional payment processor.

