### PR TITLE
Combine address first_name and last_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 config.json
-gorm.db
+*.db
 gocommerce
 
 vendor/

--- a/api/order_test.go
+++ b/api/order_test.go
@@ -33,7 +33,7 @@ func TestOrderCreate(t *testing.T) {
 		body := strings.NewReader(`{
 			"email": "info@example.com",
 			"shipping_address": {
-				"first_name": "Test", "last_name": "User",
+				"name": "Test User",
 				"address1": "610 22nd Street",
 				"city": "San Francisco", "state": "CA", "country": "USA", "zip": "94107"
 			},
@@ -60,7 +60,7 @@ func TestOrderCreate(t *testing.T) {
 		body := strings.NewReader(`{
 			"email": "info@example.com",
 			"shipping_address": {
-				"first_name": "Test", "last_name": "User",
+				"name": "Test User",
 				"address1": "Branengebranen",
 				"city": "Berlin", "country": "Germany", "zip": "94107"
 			},
@@ -86,7 +86,7 @@ func TestOrderCreate(t *testing.T) {
 		body := strings.NewReader(`{
 			"email": "info@example.com",
 			"shipping_address": {
-				"first_name": "Test", "last_name": "User",
+				"name": "Test User",
 				"address1": "Branengebranen",
 				"city": "Berlin", "country": "Germany", "zip": "94107"
 			},

--- a/api/order_test.go
+++ b/api/order_test.go
@@ -54,6 +54,26 @@ func TestOrderCreate(t *testing.T) {
 		require.True(t, ok, "Line item should have attendees")
 	})
 
+	t.Run("NameBackwardsCompatible", func(t *testing.T) {
+		test := NewRouteTest(t)
+		test.Config.SiteURL = server.URL
+		body := strings.NewReader(`{
+			"email": "info@example.com",
+			"shipping_address": {
+				"first_name": "Test", "last_name": "User",
+				"address1": "610 22nd Street",
+				"city": "San Francisco", "state": "CA", "country": "USA", "zip": "94107"
+			},
+			"line_items": [{"path": "/simple-product", "quantity": 1, "meta": {"attendees": [{"name": "Matt", "email": "matt@example.com"}]}}]
+		}`)
+		token := test.Data.testUserToken
+		recorder := test.TestEndpoint(http.MethodPost, "/orders", body, token)
+
+		order := &models.Order{}
+		extractPayload(t, http.StatusCreated, recorder, order)
+		assert.Equal(t, "Test User", order.ShippingAddress.Name)
+	})
+
 	t.Run("WithTaxes", func(t *testing.T) {
 		test := NewRouteTest(t)
 		test.Config.SiteURL = server.URL

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -292,7 +292,7 @@ func TestUserAddressCreate(t *testing.T) {
 	t.Run("Invalid", func(t *testing.T) {
 		test := NewRouteTest(t)
 		addr := getTestAddress()
-		addr.LastName = "" // required field
+		addr.Name = "" // required field
 		b, err := json.Marshal(&addr.AddressRequest)
 		require.NoError(t, err)
 

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -135,7 +135,7 @@ func setupTestData() *TestData {
 	testAddress := models.Address{
 		ID: "first-address",
 		AddressRequest: models.AddressRequest{
-			LastName: "wayne",
+			Name:     "wayne",
 			Address1: "123 cave way",
 			Country:  "dcland",
 			City:     "gotham",
@@ -249,12 +249,11 @@ func getTestAddress() *models.Address {
 	return &models.Address{
 		ID: "spidermans-house",
 		AddressRequest: models.AddressRequest{
-			LastName:  "parker",
-			FirstName: "Peter",
-			Address1:  "123 spidey lane",
-			Country:   "marvel-land",
-			City:      "new york",
-			Zip:       "10007",
+			Name:     "Peter Parker",
+			Address1: "123 spidey lane",
+			Country:  "marvel-land",
+			City:     "new york",
+			Zip:      "10007",
 		},
 	}
 }
@@ -291,8 +290,7 @@ func validateUser(t *testing.T, expected *models.User, actual *models.User) {
 
 func validateAddress(t *testing.T, expected models.Address, actual models.Address) {
 	assert := assert.New(t)
-	assert.Equal(expected.FirstName, actual.FirstName)
-	assert.Equal(expected.LastName, actual.LastName)
+	assert.Equal(expected.Name, actual.Name)
 	assert.Equal(expected.Company, actual.Company)
 	assert.Equal(expected.Address1, actual.Address1)
 	assert.Equal(expected.Address2, actual.Address2)

--- a/models/address.go
+++ b/models/address.go
@@ -8,8 +8,7 @@ import (
 
 // AddressRequest is the raw address data
 type AddressRequest struct {
-	FirstName string `json:"first_name"`
-	LastName  string `json:"last_name"`
+	Name string `json:"name"`
 
 	Company  string `json:"company"`
 	Address1 string `json:"address1"`
@@ -41,11 +40,11 @@ func (Address) TableName() string {
 // Validate validates the AddressRequest model
 func (a AddressRequest) Validate() error {
 	required := map[string]string{
-		"last name": a.LastName,
-		"address":   a.Address1,
-		"country":   a.Country,
-		"city":      a.City,
-		"zip":       a.Zip,
+		"name":    a.Name,
+		"address": a.Address1,
+		"country": a.Country,
+		"city":    a.City,
+		"zip":     a.Zip,
 	}
 
 	missing := []string{}


### PR DESCRIPTION
**- Summary**

Singular names are easier to deal with and accomodate all the different styles of naming without assuming a Western-style first and last name. Also, most payment processors only expect a singular name.

**- Test plan**

Existing automated tests pass

**- Description for the changelog**

Use a single `name` for addresses, instead of `first_name` and `last_name`.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1010430/28181829-f51cf8c2-67d7-11e7-856d-16093892870b.png)
