### PR TITLE
Add support for PayPal refunds

### DIFF
--- a/api/payments.go
+++ b/api/payments.go
@@ -300,7 +300,7 @@ func (a *API) PaymentRefund(ctx context.Context, w http.ResponseWriter, r *http.
 	tx.Create(m)
 	provID := provider.Name()
 	log.Debugf("Starting refund to %s", provID)
-	refundID, err := refund(trans.ProcessorID, params.Amount)
+	refundID, err := refund(trans.ProcessorID, params.Amount, params.Currency)
 	if err != nil {
 		log.WithError(err).Info("Failed to refund value")
 		m.FailureCode = strconv.FormatInt(http.StatusInternalServerError, 10)

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -23,7 +23,7 @@ type Provider interface {
 type Charger func(amount uint64, currency string) (string, error)
 
 // Refunder wraps the Refund method which refunds payments with the provider.
-type Refunder func(transactionID string, amount uint64) (string, error)
+type Refunder func(transactionID string, amount uint64, currency string) (string, error)
 
 // Preauthorizer wraps the Preauthorize method which pre-authorizes a payment
 // with the provider.

--- a/payments/paypal/paypal.go
+++ b/payments/paypal/paypal.go
@@ -117,8 +117,19 @@ func (p *paypalPaymentProvider) charge(paymentID string, userID string, amount u
 }
 
 func (p *paypalPaymentProvider) NewRefunder(ctx context.Context, r *http.Request) (payments.Refunder, error) {
-	// TODO ~ refund via paypal #58
-	return nil, errors.New("PayPal provider does not support refunds")
+	return p.refund, nil
+}
+
+func (p *paypalPaymentProvider) refund(transactionID string, amount uint64, currency string) (string, error) {
+	amt := &paypalsdk.Amount{
+		Total:    strconv.FormatUint(amount, 10),
+		Currency: currency,
+	}
+	ref, err := p.client.RefundSale(transactionID, amt)
+	if err != nil {
+		return "", err
+	}
+	return ref.ID, nil
 }
 
 func (p *paypalPaymentProvider) NewPreauthorizer(ctx context.Context, r *http.Request) (payments.Preauthorizer, error) {

--- a/payments/stripe/stripe.go
+++ b/payments/stripe/stripe.go
@@ -78,7 +78,7 @@ func (s *stripePaymentProvider) NewRefunder(ctx context.Context, r *http.Request
 	return s.refund, nil
 }
 
-func (s *stripePaymentProvider) refund(transactionID string, amount uint64) (string, error) {
+func (s *stripePaymentProvider) refund(transactionID string, amount uint64, currency string) (string, error) {
 	ref, err := s.client.Refunds.New(&stripe.RefundParams{
 		Charge: transactionID,
 		Amount: amount,


### PR DESCRIPTION
Fixes #58

**- Summary**

Add support for PayPal refunds.

**- Test plan**

Modified existing automated test to verify refunds work correctly.

**- Description for the changelog**

Add support for PayPal refunds.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1010430/28183432-6d47284a-67dd-11e7-9c2b-fb158d316f68.png)

