### PR TITLE
Re-add support for multiple payment providers

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -149,8 +149,8 @@ func (a *API) populateContext(ctx context.Context, w http.ResponseWriter, r *htt
 	ctx = gcontext.WithLogger(ctx, log)
 	ctx = gcontext.WithStartTime(ctx, time.Now())
 
-	if gcontext.GetPaymentProvider(ctx) == nil {
-		internalServerError(w, "No payment provider configured")
+	if gcontext.GetPaymentProviders(ctx) == nil {
+		internalServerError(w, "No payment providers configured")
 		return nil
 	}
 
@@ -171,11 +171,14 @@ func withTenantConfig(ctx context.Context, config *conf.Configuration) (context.
 	}
 	ctx = gcontext.WithAssetStore(ctx, store)
 
-	prov, err := createPaymentProvider(config)
+	provs, err := createPaymentProviders(config)
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating payment provider")
+		return nil, errors.Wrap(err, "error creating payment providers")
 	}
-	ctx = gcontext.WithPaymentProvider(ctx, prov)
+	if len(provs) == 0 {
+		return nil, errors.Wrap(err, "No payment providers enabled")
+	}
+	ctx = gcontext.WithPaymentProviders(ctx, provs)
 
 	return ctx, nil
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -11,14 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/netlify/gocommerce/conf"
-	"github.com/netlify/gocommerce/payments"
 )
 
 func TestTraceWrapper(t *testing.T) {
 	l, hook := test.NewNullLogger()
 	globalConfig := new(conf.GlobalConfiguration)
 	config := new(conf.Configuration)
-	config.Payment.ProviderType = payments.StripeProvider
+	config.Payment.Stripe.Enabled = true
 	config.Payment.Stripe.SecretKey = "secret"
 
 	api := NewAPI(globalConfig, config, nil)

--- a/api/payments.go
+++ b/api/payments.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/guregu/kami"
@@ -101,7 +102,7 @@ func (a *API) PaymentCreate(ctx context.Context, w http.ResponseWriter, r *http.
 		return
 	}
 
-	provider := gcontext.GetPaymentProviders(ctx)[params.ProviderType]
+	provider := gcontext.GetPaymentProviders(ctx)[strings.ToLower(params.ProviderType)]
 	if provider == nil {
 		badRequestError(w, "Payment provider '%s' not configured", params.ProviderType)
 		return
@@ -337,7 +338,7 @@ func (a *API) PaymentRefund(ctx context.Context, w http.ResponseWriter, r *http.
 
 // PreauthorizePayment creates a new payment that can be authorized in the browser
 func (a *API) PreauthorizePayment(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	providerType := r.FormValue("provider")
+	providerType := strings.ToLower(r.FormValue("provider"))
 	if providerType == "" {
 		badRequestError(w, "Preauthorizing a payment requires specifying a 'provider'")
 		return

--- a/api/payments.go
+++ b/api/payments.go
@@ -283,6 +283,10 @@ func (a *API) PaymentRefund(ctx context.Context, w http.ResponseWriter, r *http.
 		sendJSON(w, httpErr.Code, httpErr)
 		return
 	}
+	if order.PaymentProcessor == "" {
+		internalServerError(w, "Order does not specify a payment provider")
+		return
+	}
 
 	provider := gcontext.GetPaymentProviders(ctx)[order.PaymentProcessor]
 	if provider == nil {

--- a/api/payments.go
+++ b/api/payments.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/pkg/errors"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/guregu/kami"
 	"github.com/jinzhu/gorm"
@@ -25,8 +23,9 @@ import (
 
 // PaymentParams holds the parameters for creating a payment
 type PaymentParams struct {
-	Amount   uint64 `json:"amount"`
-	Currency string `json:"currency"`
+	Amount       uint64 `json:"amount"`
+	Currency     string `json:"currency"`
+	ProviderType string `json:"provider"`
 }
 
 // PaymentListForUser is the endpoint for listing transactions for a user.
@@ -90,17 +89,26 @@ func (a *API) PaymentCreate(ctx context.Context, w http.ResponseWriter, r *http.
 	log := gcontext.GetLogger(ctx)
 	config := gcontext.GetConfig(ctx)
 	mailer := gcontext.GetMailer(ctx)
-	provider := gcontext.GetPaymentProvider(ctx)
-	charge, err := provider.NewCharger(ctx, r)
+
+	params := PaymentParams{Currency: "USD"}
+	err := json.NewDecoder(r.Body).Decode(&params)
 	if err != nil {
-		badRequestError(w, "Error creating payment provider: %v", err)
+		badRequestError(w, "Could not read params: %v", err)
+		return
+	}
+	if params.ProviderType == "" {
+		badRequestError(w, "Creating a payment requires specifying a 'provider'")
 		return
 	}
 
-	params := PaymentParams{Currency: "USD"}
-	err = json.NewDecoder(r.Body).Decode(&params)
+	provider := getRequestedProvider(ctx, params.ProviderType)
+	if provider == nil {
+		badRequestError(w, "Payment provider '%s' not configured", params.ProviderType)
+		return
+	}
+	charge, err := provider.NewCharger(ctx, r)
 	if err != nil {
-		badRequestError(w, "Could not read params: %v", err)
+		badRequestError(w, "Error creating payment provider: %v", err)
 		return
 	}
 
@@ -276,15 +284,14 @@ func (a *API) PaymentRefund(ctx context.Context, w http.ResponseWriter, r *http.
 		return
 	}
 
-	provider := gcontext.GetPaymentProvider(ctx)
+	provider := getRequestedProvider(ctx, order.PaymentProcessor)
+	if provider == nil {
+		badRequestError(w, "Payment provider '%s' not configured", order.PaymentProcessor)
+		return
+	}
 	refund, err := provider.NewRefunder(ctx, r)
 	if err != nil {
 		badRequestError(w, "Error creating payment provider: %v", err)
-		return
-	}
-
-	if provider.Name() != order.PaymentProcessor {
-		badRequestError(w, "Order does not match configured payment provider")
 		return
 	}
 
@@ -326,7 +333,17 @@ func (a *API) PaymentRefund(ctx context.Context, w http.ResponseWriter, r *http.
 
 // PreauthorizePayment creates a new payment that can be authorized in the browser
 func (a *API) PreauthorizePayment(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	provider := gcontext.GetPaymentProvider(ctx)
+	providerType := r.FormValue("provider")
+	if providerType == "" {
+		badRequestError(w, "Preauthorizing a payment requires specifying a 'provider'")
+		return
+	}
+
+	provider := getRequestedProvider(ctx, providerType)
+	if provider == nil {
+		badRequestError(w, "Payment provider '%s' not configured", providerType)
+		return
+	}
 	preauthorize, err := provider.NewPreauthorizer(ctx, r)
 	if err != nil {
 		badRequestError(w, "Error creating payment provider: %v", err)
@@ -458,21 +475,38 @@ func queryForTransactions(db *gorm.DB, log *logrus.Entry, clause, id string) ([]
 	return trans, nil
 }
 
-// createPaymentProvider creates an instance of Provider based on the configuration
+// createPaymentProviders creates instance(s) of Provider based on the configuration
 // provided.
-func createPaymentProvider(c *conf.Configuration) (payments.Provider, error) {
-	switch c.Payment.ProviderType {
-	case payments.StripeProvider:
-		return stripe.NewPaymentProvider(stripe.Config{
+func createPaymentProviders(c *conf.Configuration) ([]payments.Provider, error) {
+	provs := []payments.Provider{}
+	if c.Payment.Stripe.Enabled {
+		p, err := stripe.NewPaymentProvider(stripe.Config{
 			SecretKey: c.Payment.Stripe.SecretKey,
 		})
-	case payments.PayPalProvider:
-		return paypal.NewPaymentProvider(paypal.Config{
+		if err != nil {
+			return nil, err
+		}
+		provs = append(provs, p)
+	}
+	if c.Payment.PayPal.Enabled {
+		p, err := paypal.NewPaymentProvider(paypal.Config{
 			Env:      c.Payment.PayPal.Env,
 			ClientID: c.Payment.PayPal.ClientID,
 			Secret:   c.Payment.PayPal.Secret,
 		})
-	default:
-		return nil, errors.Errorf("unknown payment provider: %s", c.Payment.ProviderType)
+		if err != nil {
+			return nil, err
+		}
+		provs = append(provs, p)
 	}
+	return provs, nil
+}
+
+func getRequestedProvider(ctx context.Context, name string) payments.Provider {
+	for _, p := range gcontext.GetPaymentProviders(ctx) {
+		if p.Name() == name {
+			return p
+		}
+	}
+	return nil
 }

--- a/api/payments_test.go
+++ b/api/payments_test.go
@@ -372,7 +372,7 @@ func TestPaymentsRefundSuccess(t *testing.T) {
 	provider := &memProvider{name: payments.StripeProvider}
 	ctx := testContext(testToken("magical-unicorn", ""), config, true)
 	ctx = kami.SetParam(ctx, "pay_id", firstTransaction.ID)
-	ctx = gcontext.WithPaymentProviders(ctx, []payments.Provider{provider})
+	ctx = gcontext.WithPaymentProviders(ctx, map[string]payments.Provider{payments.StripeProvider: provider})
 
 	params := &stripePaymentParams{
 		Amount:      1,

--- a/api/payments_test.go
+++ b/api/payments_test.go
@@ -274,15 +274,15 @@ func TestPaymentsRefundPaypal(t *testing.T) {
 	defer server.Close()
 
 	db, globalConfig, config := db(t)
-	config.Payment.ProviderType = payments.PayPalProvider
+	config.Payment.PayPal.Enabled = true
 	config.Payment.PayPal.ClientID = "clientid"
 	config.Payment.PayPal.Secret = "secret"
 	config.Payment.PayPal.Env = server.URL
 	ctx := testContext(testToken("magical-unicorn", ""), config, true)
 	ctx = kami.SetParam(ctx, "pay_id", secondTransaction.ID)
-	prov, err := createPaymentProvider(config)
+	provs, err := createPaymentProviders(config)
 	require.Nil(t, err)
-	ctx = gcontext.WithPaymentProvider(ctx, prov)
+	ctx = gcontext.WithPaymentProviders(ctx, provs)
 
 	params := &paypalPaymentParams{
 		Amount:       1,
@@ -332,7 +332,7 @@ func TestPaymentsRefundUnpaid(t *testing.T) {
 
 	ctx := testContext(testToken("magical-unicorn", ""), config, true)
 	ctx = kami.SetParam(ctx, "pay_id", firstTransaction.ID)
-	ctx = gcontext.WithPaymentProvider(ctx, nil)
+	ctx = gcontext.WithPaymentProviders(ctx, nil)
 
 	params := &stripePaymentParams{
 		Amount:      1,
@@ -353,7 +353,7 @@ func runPaymentRefund(t *testing.T, params *PaymentParams) (*httptest.ResponseRe
 	db, globalConfig, config := db(t)
 	ctx := testContext(testToken("magical-unicorn", ""), config, true)
 	ctx = kami.SetParam(ctx, "pay_id", firstTransaction.ID)
-	ctx = gcontext.WithPaymentProvider(ctx, nil)
+	ctx = gcontext.WithPaymentProviders(ctx, nil)
 
 	body, _ := json.Marshal(params)
 	w := httptest.NewRecorder()
@@ -366,13 +366,13 @@ func runPaymentRefund(t *testing.T, params *PaymentParams) (*httptest.ResponseRe
 func TestPaymentsRefundSuccess(t *testing.T) {
 	db, globalConfig, config := db(t)
 	// unused, but needed to pass safety check
-	config.Payment.ProviderType = "stripe"
+	config.Payment.Stripe.Enabled = true
 	config.Payment.Stripe.SecretKey = "secret"
 
 	provider := &memProvider{name: payments.StripeProvider}
 	ctx := testContext(testToken("magical-unicorn", ""), config, true)
 	ctx = kami.SetParam(ctx, "pay_id", firstTransaction.ID)
-	ctx = gcontext.WithPaymentProvider(ctx, provider)
+	ctx = gcontext.WithPaymentProviders(ctx, []payments.Provider{provider})
 
 	params := &stripePaymentParams{
 		Amount:      1,

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/netlify/gocommerce/conf"
 	gcontext "github.com/netlify/gocommerce/context"
 	"github.com/netlify/gocommerce/models"
-	"github.com/netlify/gocommerce/payments"
 )
 
 var dbFiles []string
@@ -81,7 +80,7 @@ func testConfig() (*conf.GlobalConfiguration, *conf.Configuration) {
 	globalConfig.DB.Automigrate = true
 
 	config := new(conf.Configuration)
-	config.Payment.ProviderType = payments.StripeProvider
+	config.Payment.Stripe.Enabled = true
 	config.Payment.Stripe.SecretKey = "secret"
 	return globalConfig, config
 }

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -59,11 +59,12 @@ type Configuration struct {
 	} `mapstructure:"mailer" json:"mailer"`
 
 	Payment struct {
-		ProviderType string `mapstructure:"type" json:"type"`
-		Stripe       struct {
+		Stripe struct {
+			Enabled   bool   `mapstructure:"enabled" json:"enabled"`
 			SecretKey string `mapstructure:"secret_key" json:"secret_key"`
 		} `mapstructure:"stripe" json:"stripe"`
 		PayPal struct {
+			Enabled  bool   `mapstructure:"enabled" json:"enabled"`
 			ClientID string `mapstructure:"client_id" json:"client_id"`
 			Secret   string `mapstructure:"secret" json:"secret"`
 			Env      string `mapstructure:"env" json:"env"`

--- a/config.example.json
+++ b/config.example.json
@@ -23,11 +23,12 @@
     }
   },
   "payment": {
-    "type": "stripe",
     "stripe": {
+      "enabled": true,
       "secret_key": "Your secret key"
     },
     "paypal": {
+      "enabled": true,
       "client_id": "Your client id",
       "secret": "Your secret",
       "env": "sandbox"

--- a/context/context.go
+++ b/context/context.go
@@ -153,14 +153,14 @@ func GetAssetStore(ctx context.Context) assetstores.Store {
 	return obj.(assetstores.Store)
 }
 
-// WithPaymentProvider adds the payment provider to the context.
-func WithPaymentProvider(ctx context.Context, prov payments.Provider) context.Context {
-	return context.WithValue(ctx, paymentProviderKey, prov)
+// WithPaymentProviders adds the payment providers to the context.
+func WithPaymentProviders(ctx context.Context, provs []payments.Provider) context.Context {
+	return context.WithValue(ctx, paymentProviderKey, provs)
 }
 
-// GetPaymentProvider reads the payment provider from the context
-func GetPaymentProvider(ctx context.Context) payments.Provider {
-	provs, _ := ctx.Value(paymentProviderKey).(payments.Provider)
+// GetPaymentProviders reads the payment providers from the context
+func GetPaymentProviders(ctx context.Context) []payments.Provider {
+	provs, _ := ctx.Value(paymentProviderKey).([]payments.Provider)
 	return provs
 }
 

--- a/context/context.go
+++ b/context/context.go
@@ -154,13 +154,13 @@ func GetAssetStore(ctx context.Context) assetstores.Store {
 }
 
 // WithPaymentProviders adds the payment providers to the context.
-func WithPaymentProviders(ctx context.Context, provs []payments.Provider) context.Context {
+func WithPaymentProviders(ctx context.Context, provs map[string]payments.Provider) context.Context {
 	return context.WithValue(ctx, paymentProviderKey, provs)
 }
 
 // GetPaymentProviders reads the payment providers from the context
-func GetPaymentProviders(ctx context.Context) []payments.Provider {
-	provs, _ := ctx.Value(paymentProviderKey).([]payments.Provider)
+func GetPaymentProviders(ctx context.Context) map[string]payments.Provider {
+	provs, _ := ctx.Value(paymentProviderKey).(map[string]payments.Provider)
 	return provs
 }
 


### PR DESCRIPTION
**- Summary**

Payment providers must be enabled in the configuration explicitly.

Creating a payment must explicitly specify which payment provider to use via the `provider` parameter.

**- Test plan**

Automated tests pass.

**- Description for the changelog**

Re-add support for multiple payment providers, but require explicit selection and enabling.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1010430/28284482-1c7479ac-6aff-11e7-8436-c8ad54caabd2.png)
