### PR TITLE
Remove unnecessary paypal route

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -108,8 +108,6 @@ func NewAPIWithVersion(ctx context.Context, config *conf.GlobalConfiguration, db
 
 	r.Route("/paypal", func(r *router) {
 		r.Post("/", api.PreauthorizePayment)
-		// TODO is this needed? I did not see a use case in the PayPal payment flow.
-		// r.Get("/{payment_id}", api.PayPalGetPayment)
 	})
 
 	r.Route("/reports", func(r *router) {

--- a/api/payments.go
+++ b/api/payments.go
@@ -327,22 +327,6 @@ func (a *API) PreauthorizePayment(w http.ResponseWriter, r *http.Request) error 
 	return sendJSON(w, http.StatusOK, paymentResult)
 }
 
-// PayPalGetPayment retrieves information on an authorized paypal payment, including
-// the shipping address
-// func (a *API) PayPalGetPayment(w http.ResponseWriter, r *http.Request) error {
-//	ctx := r.Context()
-// 	provider, ok := getPaymentProvider(ctx).(*payments.paypalPaymentProvider)
-// 	if !ok {
-// 		return internalServerError("PayPal provider not available")
-// 	}
-// 	payment, err := provider.client.GetPayment(chi.URLParam(r, "payment_id"))
-// 	if err != nil {
-// 		return internalServerError("Error fetching paypal payment: %v", err)
-// 	}
-//
-// 	return sendJSON(w, http.StatusOK, payment)
-// }
-
 // ------------------------------------------------------------------------------------------------
 // Helpers
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**- Summary**

This route is not needed in the PayPal payment flow. It was previously being used to obtain the `payerID`, but `payerID` is being passed by PayPal's checkout.js to the client-side handler, so a call to gocommerce to obtain the `payerID` is not needed.

**- Test plan**

All tests pass.

**- Description for the changelog**

Remove unneeded get PayPal payment route.

