### PR TITLE
Add middleware that populates GetBody

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -102,12 +102,12 @@ func NewAPIWithVersion(ctx context.Context, config *conf.GlobalConfiguration, db
 		r.Get("/", api.PaymentList)
 		r.Route("/{payment_id}", func(r *router) {
 			r.Get("/", api.PaymentView)
-			r.Post("/refund", api.PaymentRefund)
+			r.With(addGetBody).Post("/refund", api.PaymentRefund)
 		})
 	})
 
 	r.Route("/paypal", func(r *router) {
-		r.Post("/", api.PreauthorizePayment)
+		r.With(addGetBody).Post("/", api.PreauthorizePayment)
 	})
 
 	r.Route("/reports", func(r *router) {
@@ -146,7 +146,7 @@ func (a *API) orderRoutes(r *router) {
 
 		r.Route("/payments", func(r *router) {
 			r.With(authRequired).Get("/", a.PaymentListForOrder)
-			r.Post("/", a.PaymentCreate)
+			r.With(addGetBody).Post("/", a.PaymentCreate)
 		})
 
 		r.Get("/downloads", a.DownloadList)

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+func addGetBody(w http.ResponseWriter, req *http.Request) (context.Context, error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil, badRequestError("request must provide a body")
+	}
+
+	buf, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, internalServerError("Error reading body").WithInternalError(err)
+	}
+	req.GetBody = func() (io.ReadCloser, error) {
+		return ioutil.NopCloser(bytes.NewReader(buf)), nil
+	}
+	req.Body, _ = req.GetBody()
+	return req.Context(), nil
+}


### PR DESCRIPTION
**- Summary**

Go does not populate `http.Request.GetBody` for server requests.

**- Test plan**

Added test that confirmed previous panic and now passes.

**- Description for the changelog**

Populate `http.Request.GetBody` for routes that need to read the body multiple times.

**- A picture of a cute animal (not mandatory but encouraged)**
