### PR TITLE
Fix creating a stripe payment

### DIFF
--- a/payments/stripe/stripe.go
+++ b/payments/stripe/stripe.go
@@ -17,7 +17,7 @@ type stripePaymentProvider struct {
 }
 
 type stripeBodyParams struct {
-	StripeToken string `mapstructure:"stripe_token"`
+	StripeToken string `json:"stripe_token"`
 }
 
 // Config contains the Stripe-specific configuration for payment providers.


### PR DESCRIPTION
**- Summary**

Creating stripe payments was failing because it was not deserializing the `stripe_token` parameter correctly.

**- Test plan**

Added a basic test that verifies all our logic works correctly, while mocking the actual Stripe interactions.

**- Description for the changelog**

Deserialize `stripe_token` correctly when creating Stripe payment.

