### PR TITLE
Set transaction to paid on successful payment

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The metadata can be anywhere on the page, and goes in a script tag in this forma
 
 ```html
 <script class="gocommerce-product" type="application/json">
-{"sku": "my-product", "title": "My Product", "prices": [{"amount": "49.99"}], "type": "ebook"}
+{"sku": "my-product", "title": "My Product", "prices": [{"amount": "49.99", "currency": "USD"}], "type": "ebook"}
 </script>
 ```
 

--- a/api/download.go
+++ b/api/download.go
@@ -40,7 +40,7 @@ func (a *API) DownloadURL(w http.ResponseWriter, r *http.Request) error {
 		return unauthorizedError("Not Authorized to access this download")
 	}
 
-	if order.PaymentState != "paid" {
+	if order.PaymentState != models.PaidState {
 		return unauthorizedError("This download has not been paid yet")
 	}
 
@@ -98,7 +98,7 @@ func (a *API) DownloadList(w http.ResponseWriter, r *http.Request) error {
 			return unauthorizedError("You don't have permission to access this order")
 		}
 
-		if order.PaymentState != "paid" {
+		if order.PaymentState != models.PaidState {
 			return unauthorizedError("This order has not been completed yet")
 		}
 	}

--- a/api/order.go
+++ b/api/order.go
@@ -697,13 +697,14 @@ func (a *API) processLineItem(ctx context.Context, order *models.Order, item *mo
 	}
 	metaProducts := []*models.LineItemMetadata{}
 	var parsingErr error
-	metaTag.Each(func(_ int, tag *goquery.Selection) {
+	metaTag.EachWithBreak(func(_ int, tag *goquery.Selection) bool {
 		meta := &models.LineItemMetadata{}
 		parsingErr = json.Unmarshal([]byte(tag.Text()), meta)
 		if parsingErr != nil {
-			return
+			return false
 		}
 		metaProducts = append(metaProducts, meta)
+		return true
 	})
 	if parsingErr != nil {
 		return fmt.Errorf("Error parsing product metadata: %v", parsingErr)

--- a/api/order.go
+++ b/api/order.go
@@ -693,19 +693,17 @@ func (a *API) processLineItem(ctx context.Context, order *models.Order, item *mo
 
 	metaTag := doc.Find(".gocommerce-product")
 	if metaTag.Length() == 0 {
-		return fmt.Errorf("No script tag with id gocommerce-product tag found for '%v'", item.Title)
+		return fmt.Errorf("No script tag with class gocommerce-product tag found for '%v'", item.Title)
 	}
 	metaProducts := []*models.LineItemMetadata{}
 	var parsingErr error
 	metaTag.Each(func(_ int, tag *goquery.Selection) {
+		meta := &models.LineItemMetadata{}
+		parsingErr = json.Unmarshal([]byte(tag.Text()), meta)
 		if parsingErr != nil {
 			return
 		}
-		meta := &models.LineItemMetadata{}
-		parsingErr = json.Unmarshal([]byte(tag.Text()), meta)
-		if parsingErr == nil {
-			metaProducts = append(metaProducts, meta)
-		}
+		metaProducts = append(metaProducts, meta)
 	})
 	if parsingErr != nil {
 		return fmt.Errorf("Error parsing product metadata: %v", parsingErr)

--- a/api/payments_test.go
+++ b/api/payments_test.go
@@ -370,6 +370,7 @@ func TestPaymentCreate(t *testing.T) {
 			rsp := models.Transaction{}
 			extractPayload(t, http.StatusOK, recorder, &rsp)
 			assert.Equal(t, paymentID, rsp.ProcessorID)
+			assert.Equal(t, models.PaidState, rsp.Status)
 			assert.Equal(t, 1, loginCount, "too many login calls")
 			assert.Equal(t, 2, paymentCount, "too many payment calls")
 		})
@@ -401,6 +402,7 @@ func TestPaymentCreate(t *testing.T) {
 
 		rsp := models.Transaction{}
 		extractPayload(t, http.StatusOK, recorder, &rsp)
+		assert.Equal(t, models.PaidState, rsp.Status)
 		assert.Equal(t, 1, callCount)
 	})
 }

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -21,13 +21,13 @@ type Transaction struct {
 	ProcessorID string `json:"processor_id"`
 
 	User   *User  `json:"-"`
-	UserID string `json:"user_id"`
+	UserID string `json:"user_id,omitempty"`
 
 	Amount   uint64 `json:"amount"`
 	Currency string `json:"currency"`
 
-	FailureCode        string `json:"failure_code"`
-	FailureDescription string `json:"failure_description"`
+	FailureCode        string `json:"failure_code,omitempty"`
+	FailureDescription string `json:"failure_description,omitempty"`
 
 	Status string `json:"status"`
 	Type   string `json:"type"`


### PR DESCRIPTION
**- Summary**

The transaction was previously being set to the `pending` status, but nothing would ever update it to `paid`. This would prevent the ability to issue refunds. In contrast, the order **was** being marked as `paid`. 

**- Test plan**

Added assertions to existing payment creation tests.

**- Description for the changelog**

Set transaction to "paid" upon successful charge.

**- A picture of a cute animal (not mandatory but encouraged)**
