### PR TITLE
Receipts endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -150,12 +150,7 @@ func (a *API) orderRoutes(r *router) {
 		})
 
 		r.Get("/downloads", a.DownloadList)
-		r.Route("/receipt", func(r *router) {
-			r.Get("/", a.ReceiptView)
-			r.Post("/", a.ResendOrderReceipt)
-			r.Get("/*", a.ReceiptView)
-		})
-
+		r.Get("/receipt", a.ReceiptView)
 	})
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -150,7 +150,12 @@ func (a *API) orderRoutes(r *router) {
 		})
 
 		r.Get("/downloads", a.DownloadList)
-		r.Post("/receipt", a.ResendOrderReceipt)
+		r.Route("/receipt", func(r *router) {
+			r.Get("/", a.ReceiptView)
+			r.Post("/", a.ResendOrderReceipt)
+			r.Get("/*", a.ReceiptView)
+		})
+
 	})
 }
 

--- a/api/order.go
+++ b/api/order.go
@@ -156,8 +156,7 @@ func (a *API) ReceiptView(w http.ResponseWriter, r *http.Request) error {
 	if !hasOrderAccess(ctx, order) {
 		return unauthorizedError("Order History Requires Authentication")
 	}
-
-	template := chi.URLParam(r, "*")
+	template := r.URL.Query().Get("template")
 
 	mailer := gcontext.GetMailer(ctx)
 	for _, transaction := range order.Transactions {

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -14,6 +14,7 @@ import (
 type Mailer interface {
 	OrderConfirmationMail(transaction *models.Transaction) error
 	OrderReceivedMail(transaction *models.Transaction) error
+	OrderReceivedMailBody(transaction *models.Transaction, templateURL string) (string, error)
 }
 
 type mailer struct {
@@ -124,6 +125,17 @@ func (m *mailer) OrderReceivedMail(transaction *models.Transaction) error {
 			"Transaction": transaction,
 		},
 	)
+}
+
+func (m *mailer) OrderReceivedMailBody(transaction *models.Transaction, templateURL string) (string, error) {
+	if templateURL == "" {
+		templateURL = m.Config.Mailer.Templates.OrderReceived
+	}
+
+	return m.TemplateMailer.MailBody(templateURL, defaultReceivedTemplate, map[string]interface{}{
+		"Order":       transaction.Order,
+		"Transaction": transaction,
+	})
 }
 
 func withDefault(value string, defaultValue string) string {

--- a/mailer/noop.go
+++ b/mailer/noop.go
@@ -14,3 +14,7 @@ func (m *noopMailer) OrderConfirmationMail(transaction *models.Transaction) erro
 func (m *noopMailer) OrderReceivedMail(transaction *models.Transaction) error {
 	return nil
 }
+
+func (m *noopMailer) OrderReceivedMailBody(transaction *models.Transaction, templateURL string) (string, error) {
+	return "Order Received", nil
+}


### PR DESCRIPTION
This adds a `/orders/:order_id/receipt` endpoint that will return the HTML receipt for the order.

By default this uses the same HTML templates as the OrderConfirmation Mailer, but the endpoint takes an optional `template` query parameter that specifies another template inside the website that can be used to generate different variation of the receipt (one for the client, maybe one for printing on a box, one representing a ticket, etc)....