### PR TITLE
Add additional order filters

### DIFF
--- a/api/order.go
+++ b/api/order.go
@@ -259,7 +259,8 @@ func (a *API) OrderList(w http.ResponseWriter, r *http.Request) error {
 		userID = claims.Subject
 	}
 	if userID != "all" {
-		query = query.Where("user_id = ?", userID)
+		orderTable := query.NewScope(models.Order{}).QuotedTableName()
+		query = query.Where(orderTable+".user_id = ?", userID)
 	}
 	log.WithField("query_user_id", userID).Debug("URL parsed and query perpared")
 

--- a/api/order_test.go
+++ b/api/order_test.go
@@ -189,6 +189,42 @@ func TestOrdersList(t *testing.T) {
 			extractPayload(t, http.StatusOK, recorder, &orders)
 			assert.Len(t, orders, 1)
 		})
+		t.Run("BillingNameFilterAsTheUser", func(t *testing.T) {
+			test := NewRouteTest(t)
+			token := test.Data.testUserToken
+			recorder := test.TestEndpoint(http.MethodGet, "/orders?billing_name=whatname", nil, token)
+
+			orders := []models.Order{}
+			extractPayload(t, http.StatusOK, recorder, &orders)
+			assert.Len(t, orders, 0)
+		})
+		t.Run("ShippingNameFilterAsTheUser", func(t *testing.T) {
+			test := NewRouteTest(t)
+			token := test.Data.testUserToken
+			recorder := test.TestEndpoint(http.MethodGet, "/orders?shipping_name=whatname", nil, token)
+
+			orders := []models.Order{}
+			extractPayload(t, http.StatusOK, recorder, &orders)
+			assert.Len(t, orders, 0)
+		})
+		t.Run("ItemTypeFilterAsTheUser", func(t *testing.T) {
+			test := NewRouteTest(t)
+			token := test.Data.testUserToken
+			recorder := test.TestEndpoint(http.MethodGet, "/orders?item_type=plane", nil, token)
+
+			orders := []models.Order{}
+			extractPayload(t, http.StatusOK, recorder, &orders)
+			assert.Len(t, orders, 1)
+		})
+		t.Run("CouponCodeFilterAsTheUser", func(t *testing.T) {
+			test := NewRouteTest(t)
+			token := test.Data.testUserToken
+			recorder := test.TestEndpoint(http.MethodGet, "/orders?coupon_code=zerodiscount", nil, token)
+
+			orders := []models.Order{}
+			extractPayload(t, http.StatusOK, recorder, &orders)
+			assert.Len(t, orders, 1)
+		})
 	})
 }
 

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -182,6 +182,7 @@ func setupTestData() *TestData {
 	firstOrder.BillingAddress = testAddress
 	firstOrder.ShippingAddress = testAddress
 	firstOrder.User = testUser
+	firstOrder.CouponCode = "zerodiscount"
 	firstTransaction.ID = "first-trans"
 
 	secondOrder := models.NewOrder("", "session2", testUser.Email, "USD")


### PR DESCRIPTION
Fixes #76 


**- Summary**

Add order filters:
`billing_name`
`shipping_name`
`item_type`
`coupon_code`

**- Test plan**

Added tests for new filters.

**- Description for the changelog**

Add additional order filters.

