### PR TITLE
Make mailer use global configu if no smtp settings in instance

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -20,7 +20,7 @@ func TestTraceWrapper(t *testing.T) {
 	config.Payment.Stripe.Enabled = true
 	config.Payment.Stripe.SecretKey = "secret"
 
-	ctx, err := WithInstanceConfig(context.Background(), globalConfig, config, "")
+	ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, config, "")
 	require.NoError(t, err)
 	api := NewAPIWithVersion(ctx, globalConfig, nil, "")
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -20,7 +20,7 @@ func TestTraceWrapper(t *testing.T) {
 	config.Payment.Stripe.Enabled = true
 	config.Payment.Stripe.SecretKey = "secret"
 
-	ctx, err := WithInstanceConfig(context.Background(), config, "")
+	ctx, err := WithInstanceConfig(context.Background(), globalConfig, config, "")
 	require.NoError(t, err)
 	api := NewAPIWithVersion(ctx, globalConfig, nil, "")
 

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -100,7 +100,7 @@ func (api *API) loadInstanceConfig(w http.ResponseWriter, r *http.Request) (cont
 	}
 	logEntrySetField(r, "site_url", config.SiteURL)
 
-	ctx, err = WithInstanceConfig(ctx, api.config, config, instanceID)
+	ctx, err = WithInstanceConfig(ctx, api.config.SMTP, config, instanceID)
 	if err != nil {
 		return nil, internalServerError("Error loading instance config").WithInternalError(err)
 	}
@@ -108,12 +108,12 @@ func (api *API) loadInstanceConfig(w http.ResponseWriter, r *http.Request) (cont
 	return ctx, nil
 }
 
-func WithInstanceConfig(ctx context.Context, global *conf.GlobalConfiguration, config *conf.Configuration, instanceID string) (context.Context, error) {
+func WithInstanceConfig(ctx context.Context, smtp conf.SMTPConfiguration, config *conf.Configuration, instanceID string) (context.Context, error) {
 	ctx = gcontext.WithInstanceID(ctx, instanceID)
 	ctx = gcontext.WithConfig(ctx, config)
 	ctx = gcontext.WithCoupons(ctx, config)
 
-	mailer := mailer.NewMailer(&global.SMTP, config)
+	mailer := mailer.NewMailer(smtp, config)
 	ctx = gcontext.WithMailer(ctx, mailer)
 
 	store, err := assetstores.NewStore(config)

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/imdario/mergo"
 	"github.com/netlify/gocommerce/assetstores"
 	"github.com/netlify/gocommerce/conf"
 	gcontext "github.com/netlify/gocommerce/context"
@@ -100,13 +99,6 @@ func (api *API) loadInstanceConfig(w http.ResponseWriter, r *http.Request) (cont
 		config.SiteURL = claims.SiteURL
 	}
 	logEntrySetField(r, "site_url", config.SiteURL)
-
-	log := getLogEntry(r)
-	log.Info("API config: %v", api.config)
-	log.Info("Instance config: %v", config)
-	if err = mergo.MergeWithOverwrite(config, api.config); err != nil {
-		return nil, internalServerError("Failed to instantiate instance config").WithInternalError(err)
-	}
 
 	ctx, err = WithInstanceConfig(ctx, api.config, config, instanceID)
 	if err != nil {

--- a/api/payments_test.go
+++ b/api/payments_test.go
@@ -19,6 +19,7 @@ import (
 
 	"strings"
 
+	"github.com/netlify/gocommerce/conf"
 	gcontext "github.com/netlify/gocommerce/context"
 	"github.com/netlify/gocommerce/models"
 	"github.com/netlify/gocommerce/payments"
@@ -231,8 +232,9 @@ func TestPaymentsRefund(t *testing.T) {
 		test.Config.Payment.Stripe.Enabled = true
 		test.Config.Payment.Stripe.SecretKey = "secret"
 
+		globalConfig := new(conf.GlobalConfiguration)
 		provider := &memProvider{name: payments.StripeProvider}
-		ctx, err := WithInstanceConfig(context.Background(), test.Config, "")
+		ctx, err := WithInstanceConfig(context.Background(), globalConfig, test.Config, "")
 		require.NoError(t, err)
 		ctx = gcontext.WithPaymentProviders(ctx, map[string]payments.Provider{payments.StripeProvider: provider})
 
@@ -462,7 +464,8 @@ func TestPaymentPreauthorize(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, baseURL+testURL, strings.NewReader(form.Encode()))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
 
-			ctx, err := WithInstanceConfig(context.Background(), test.Config, "")
+			globalConfig := new(conf.GlobalConfiguration)
+			ctx, err := WithInstanceConfig(context.Background(), globalConfig, test.Config, "")
 			require.NoError(t, err)
 			NewAPIWithVersion(ctx, test.GlobalConfig, test.DB, "").handler.ServeHTTP(recorder, req)
 
@@ -501,7 +504,9 @@ func TestPaymentPreauthorize(t *testing.T) {
 			recorder := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, baseURL+testURL, bytes.NewBuffer(body))
 			req.Header.Set("Content-Type", "application/json")
-			ctx, err := WithInstanceConfig(context.Background(), test.Config, "")
+
+			globalConfig := new(conf.GlobalConfiguration)
+			ctx, err := WithInstanceConfig(context.Background(), globalConfig, test.Config, "")
 			require.NoError(t, err)
 			NewAPIWithVersion(ctx, test.GlobalConfig, test.DB, "").handler.ServeHTTP(recorder, req)
 

--- a/api/payments_test.go
+++ b/api/payments_test.go
@@ -234,7 +234,7 @@ func TestPaymentsRefund(t *testing.T) {
 
 		globalConfig := new(conf.GlobalConfiguration)
 		provider := &memProvider{name: payments.StripeProvider}
-		ctx, err := WithInstanceConfig(context.Background(), globalConfig, test.Config, "")
+		ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, test.Config, "")
 		require.NoError(t, err)
 		ctx = gcontext.WithPaymentProviders(ctx, map[string]payments.Provider{payments.StripeProvider: provider})
 
@@ -465,7 +465,7 @@ func TestPaymentPreauthorize(t *testing.T) {
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
 
 			globalConfig := new(conf.GlobalConfiguration)
-			ctx, err := WithInstanceConfig(context.Background(), globalConfig, test.Config, "")
+			ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, test.Config, "")
 			require.NoError(t, err)
 			NewAPIWithVersion(ctx, test.GlobalConfig, test.DB, "").handler.ServeHTTP(recorder, req)
 
@@ -506,7 +506,7 @@ func TestPaymentPreauthorize(t *testing.T) {
 			req.Header.Set("Content-Type", "application/json")
 
 			globalConfig := new(conf.GlobalConfiguration)
-			ctx, err := WithInstanceConfig(context.Background(), globalConfig, test.Config, "")
+			ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, test.Config, "")
 			require.NoError(t, err)
 			NewAPIWithVersion(ctx, test.GlobalConfig, test.DB, "").handler.ServeHTTP(recorder, req)
 

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -348,7 +348,8 @@ func (r *RouteTest) TestEndpoint(method string, url string, body io.Reader, toke
 	if token != nil {
 		require.NoError(r.T, signHTTPRequest(req, token, r.Config.JWT.Secret))
 	}
-	ctx, err := WithInstanceConfig(context.Background(), r.Config, "")
+	globalConfig := new(conf.GlobalConfiguration)
+	ctx, err := WithInstanceConfig(context.Background(), globalConfig, r.Config, "")
 	require.NoError(r.T, err)
 	NewAPIWithVersion(ctx, r.GlobalConfig, r.DB, "").handler.ServeHTTP(recorder, req)
 

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -349,7 +349,7 @@ func (r *RouteTest) TestEndpoint(method string, url string, body io.Reader, toke
 		require.NoError(r.T, signHTTPRequest(req, token, r.Config.JWT.Secret))
 	}
 	globalConfig := new(conf.GlobalConfiguration)
-	ctx, err := WithInstanceConfig(context.Background(), globalConfig, r.Config, "")
+	ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, r.Config, "")
 	require.NoError(r.T, err)
 	NewAPIWithVersion(ctx, r.GlobalConfig, r.DB, "").handler.ServeHTTP(recorder, req)
 

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -32,7 +32,7 @@ func serve(globalConfig *conf.GlobalConfiguration, config *conf.Configuration) {
 	}
 	defer bgDB.Close()
 
-	ctx, err := api.WithInstanceConfig(context.Background(), globalConfig, config, "")
+	ctx, err := api.WithInstanceConfig(context.Background(), globalConfig.SMTP, config, "")
 	if err != nil {
 		logrus.Fatalf("Error loading instance config: %+v", err)
 	}

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -32,7 +32,7 @@ func serve(globalConfig *conf.GlobalConfiguration, config *conf.Configuration) {
 	}
 	defer bgDB.Close()
 
-	ctx, err := api.WithInstanceConfig(context.Background(), config, "")
+	ctx, err := api.WithInstanceConfig(context.Background(), globalConfig, config, "")
 	if err != nil {
 		logrus.Fatalf("Error loading instance config: %+v", err)
 	}

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"os"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
@@ -23,6 +24,15 @@ type JWTConfiguration struct {
 	AdminGroupName string `json:"admin_group_name" split_words:"true"`
 }
 
+type SMTPConfiguration struct {
+	MaxFrequency time.Duration `json:"max_frequency" split_words:"true"`
+	Host         string        `json:"host"`
+	Port         int           `json:"port" default:"587"`
+	User         string        `json:"user"`
+	Pass         string        `json:"pass"`
+	AdminEmail   string        `json:"admin_email" split_words:"true"`
+}
+
 // GlobalConfiguration holds all the global configuration for gocommerce
 type GlobalConfiguration struct {
 	API struct {
@@ -34,6 +44,7 @@ type GlobalConfiguration struct {
 	Logging           nconf.LoggingConfig `envconfig:"LOG"`
 	OperatorToken     string              `split_words:"true"`
 	MultiInstanceMode bool
+	SMTP              SMTPConfiguration `json:"smtp"`
 }
 
 // EmailContentConfiguration holds the configuration for emails, both subjects and template URLs.
@@ -47,11 +58,9 @@ type Configuration struct {
 	SiteURL string           `json:"site_url" split_words:"true"`
 	JWT     JWTConfiguration `json:"jwt"`
 
+	SMTP SMTPConfiguration `json:"smtp"`
+
 	Mailer struct {
-		Host       string                    `json:"host"`
-		Port       int                       `json:"port"`
-		User       string                    `json:"user"`
-		Pass       string                    `json:"pass"`
 		AdminEmail string                    `json:"admin_email" split_words:"true"`
 		Subjects   EmailContentConfiguration `json:"subjects"`
 		Templates  EmailContentConfiguration `json:"templates"`

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -2,7 +2,6 @@ package conf
 
 import (
 	"os"
-	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
@@ -25,12 +24,11 @@ type JWTConfiguration struct {
 }
 
 type SMTPConfiguration struct {
-	MaxFrequency time.Duration `json:"max_frequency" split_words:"true"`
-	Host         string        `json:"host"`
-	Port         int           `json:"port" default:"587"`
-	User         string        `json:"user"`
-	Pass         string        `json:"pass"`
-	AdminEmail   string        `json:"admin_email" split_words:"true"`
+	Host       string `json:"host"`
+	Port       int    `json:"port" default:"587"`
+	User       string `json:"user"`
+	Pass       string `json:"pass"`
+	AdminEmail string `json:"admin_email" split_words:"true"`
 }
 
 // GlobalConfiguration holds all the global configuration for gocommerce
@@ -61,9 +59,8 @@ type Configuration struct {
 	SMTP SMTPConfiguration `json:"smtp"`
 
 	Mailer struct {
-		AdminEmail string                    `json:"admin_email" split_words:"true"`
-		Subjects   EmailContentConfiguration `json:"subjects"`
-		Templates  EmailContentConfiguration `json:"templates"`
+		Subjects  EmailContentConfiguration `json:"subjects"`
+		Templates EmailContentConfiguration `json:"templates"`
 	} `json:"mailer"`
 
 	Payment struct {

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -28,7 +28,7 @@ type MailSubjects struct {
 }
 
 // NewMailer returns a new authlify mailer
-func NewMailer(smtp *conf.SMTPConfiguration, instanceConfig *conf.Configuration) Mailer {
+func NewMailer(smtp conf.SMTPConfiguration, instanceConfig *conf.Configuration) Mailer {
 	if smtp.Host == "" && instanceConfig.SMTP.Host == "" {
 		return newNoopMailer()
 	}
@@ -52,10 +52,6 @@ func NewMailer(smtp *conf.SMTPConfiguration, instanceConfig *conf.Configuration)
 	smtpAdminEmail := instanceConfig.SMTP.AdminEmail
 	if smtpAdminEmail == "" {
 		smtpAdminEmail = smtp.AdminEmail
-	}
-	smtpMaxFrequency := instanceConfig.SMTP.MaxFrequency
-	if smtpMaxFrequency == 0 {
-		smtpMaxFrequency = smtp.MaxFrequency
 	}
 
 	return &mailer{
@@ -140,7 +136,7 @@ const defaultReceivedTemplate = `<h2>Order Received From {{ .Order.Email }}</h2>
 // OrderReceivedMail sends a notification to the shop admin
 func (m *mailer) OrderReceivedMail(transaction *models.Transaction) error {
 	return m.TemplateMailer.Mail(
-		m.Config.Mailer.AdminEmail,
+		m.TemplateMailer.From,
 		withDefault(m.Config.Mailer.Subjects.OrderReceived, "Order Received From {{ .Order.Email }}"),
 		m.Config.Mailer.Templates.OrderReceived,
 		defaultReceivedTemplate,

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -28,21 +28,45 @@ type MailSubjects struct {
 }
 
 // NewMailer returns a new authlify mailer
-func NewMailer(conf *conf.Configuration) Mailer {
-	mailConf := conf.Mailer
-	if mailConf.AdminEmail == "" || mailConf.Host == "" || mailConf.Port == 0 {
+func NewMailer(smtp *conf.SMTPConfiguration, instanceConfig *conf.Configuration) Mailer {
+	if smtp.Host == "" && instanceConfig.SMTP.Host == "" {
 		return newNoopMailer()
 	}
 
+	smtpHost := instanceConfig.SMTP.Host
+	if smtpHost == "" {
+		smtpHost = smtp.Host
+	}
+	smtpPort := instanceConfig.SMTP.Port
+	if smtpPort == 0 {
+		smtpPort = smtp.Port
+	}
+	smtpUser := instanceConfig.SMTP.User
+	if smtpUser == "" {
+		smtpUser = smtp.User
+	}
+	smtpPass := instanceConfig.SMTP.Pass
+	if smtpPass == "" {
+		smtpPass = smtp.Pass
+	}
+	smtpAdminEmail := instanceConfig.SMTP.AdminEmail
+	if smtpAdminEmail == "" {
+		smtpAdminEmail = smtp.AdminEmail
+	}
+	smtpMaxFrequency := instanceConfig.SMTP.MaxFrequency
+	if smtpMaxFrequency == 0 {
+		smtpMaxFrequency = smtp.MaxFrequency
+	}
+
 	return &mailer{
-		Config: conf,
+		Config: instanceConfig,
 		TemplateMailer: &mailme.Mailer{
-			BaseURL: conf.SiteURL,
-			From:    mailConf.AdminEmail,
-			Host:    mailConf.Host,
-			Port:    mailConf.Port,
-			User:    mailConf.User,
-			Pass:    mailConf.Pass,
+			Host:    smtpHost,
+			Port:    smtpPort,
+			User:    smtpUser,
+			Pass:    smtpPass,
+			From:    smtpAdminEmail,
+			BaseURL: instanceConfig.SiteURL,
 			FuncMap: map[string]interface{}{
 				"dateFormat":     dateFormat,
 				"price":          price,

--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -8,19 +8,19 @@ import (
 )
 
 func TestNoopMailer(t *testing.T) {
-	smtp := &conf.SMTPConfiguration{}
+	smtp := conf.SMTPConfiguration{}
 	conf := &conf.Configuration{}
 	m := NewMailer(smtp, conf)
 	assert.IsType(t, &noopMailer{}, m)
 }
 
 func TestTemplateMailer(t *testing.T) {
-	smtp := &conf.SMTPConfiguration{
+	smtp := conf.SMTPConfiguration{
 		Host: "localhost",
 		Port: 25,
 	}
 	conf := &conf.Configuration{}
-	conf.Mailer.AdminEmail = "test@example.com"
+	conf.SMTP.AdminEmail = "test@example.com"
 	m := NewMailer(smtp, conf)
 	assert.IsType(t, &mailer{}, m)
 }

--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -8,16 +8,19 @@ import (
 )
 
 func TestNoopMailer(t *testing.T) {
+	smtp := &conf.SMTPConfiguration{}
 	conf := &conf.Configuration{}
-	m := NewMailer(conf)
+	m := NewMailer(smtp, conf)
 	assert.IsType(t, &noopMailer{}, m)
 }
 
 func TestTemplateMailer(t *testing.T) {
+	smtp := &conf.SMTPConfiguration{
+		Host: "localhost",
+		Port: 25,
+	}
 	conf := &conf.Configuration{}
 	conf.Mailer.AdminEmail = "test@example.com"
-	conf.Mailer.Host = "localhost"
-	conf.Mailer.Port = 25
-	m := NewMailer(conf)
+	m := NewMailer(smtp, conf)
 	assert.IsType(t, &mailer{}, m)
 }


### PR DESCRIPTION
This implements the same distinction between smtp and mail settings
that gotrue uses.