### PR TITLE
Add column type to force MySQL

### DIFF
--- a/models/hook.go
+++ b/models/hook.go
@@ -31,13 +31,13 @@ type Hook struct {
 	Failed bool
 
 	URL     string
-	Payload string
+	Payload string `sql:"type:text"`
 	Secret  string
 
 	ResponseStatus  string
-	ResponseHeaders string
-	ResponseBody    string
-	ErrorMessage    *string
+	ResponseHeaders string  `sql:"type:text"`
+	ResponseBody    string  `sql:"type:text"`
+	ErrorMessage    *string `sql:"type:text"`
 
 	Tries int
 

--- a/models/instance.go
+++ b/models/instance.go
@@ -17,7 +17,7 @@ type Instance struct {
 	// Netlify UUID
 	UUID string `json:"uuid,omitempty"`
 
-	RawBaseConfig string              `json:"-" gorm:"size:65535"`
+	RawBaseConfig string              `json:"-" sql:"type:text"`
 	BaseConfig    *conf.Configuration `json:"config"`
 
 	CreatedAt time.Time  `json:"created_at"`

--- a/models/line_item.go
+++ b/models/line_item.go
@@ -21,7 +21,7 @@ type LineItem struct {
 	Title       string `json:"title"`
 	Sku         string `json:"sku"`
 	Type        string `json:"type"`
-	Description string `json:"description"`
+	Description string `json:"description" sql:"type:text"`
 
 	Path string `json:"path"`
 
@@ -35,7 +35,7 @@ type LineItem struct {
 	Quantity uint64 `json:"quantity"`
 
 	MetaData    map[string]interface{} `sql:"-" json:"meta"`
-	RawMetaData string                 `json:"-"`
+	RawMetaData string                 `json:"-" sql:"type:text"`
 
 	CreatedAt time.Time  `json:"-"`
 	DeletedAt *time.Time `json:"-"`

--- a/models/order.go
+++ b/models/order.go
@@ -74,12 +74,12 @@ type Order struct {
 	VATNumber string `json:"vatnumber"`
 
 	MetaData    map[string]interface{} `sql:"-" json:"meta"`
-	RawMetaData string                 `json:"-"`
+	RawMetaData string                 `json:"-" sql:"type:text"`
 
 	CouponCode string `json:"coupon_code,omitempty"`
 
 	Coupon    *Coupon `json:"coupon,omitempty" sql:"-"`
-	RawCoupon string  `json:"-"`
+	RawCoupon string  `json:"-" sql:"type:text"`
 
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`

--- a/models/order_notes.go
+++ b/models/order_notes.go
@@ -8,7 +8,7 @@ type OrderNote struct {
 
 	UserID string `json:"user_id"`
 
-	Text string `json:"text"`
+	Text string `json:"text" sql:"type:text"`
 
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -29,7 +29,7 @@ type Transaction struct {
 	Currency string `json:"currency"`
 
 	FailureCode        string `json:"failure_code,omitempty"`
-	FailureDescription string `json:"failure_description,omitempty"`
+	FailureDescription string `json:"failure_description,omitempty" sql:"type:text"`
 
 	Status string `json:"status"`
 	Type   string `json:"type"`


### PR DESCRIPTION
Default gorm string column size is 255, which is not sufficient for some columns.
