### PR TITLE
Fix downloads getting persisted without order id

### DIFF
--- a/models/line_item.go
+++ b/models/line_item.go
@@ -262,6 +262,7 @@ func (i *LineItem) Process(userClaims map[string]interface{}, order *Order, meta
 			continue
 		}
 		download.ID = uuid.NewRandom().String()
+		download.OrderID = order.ID
 		download.Title = i.Title
 		download.Sku = i.Sku
 		order.Downloads = append(order.Downloads, download)


### PR DESCRIPTION
Downloads were getting persisted without any order ID, which means they never show up when querying for the order.