### PR TITLE
Paypal expects amount to be xx.xx not xxxx

### DIFF
--- a/api/payments_test.go
+++ b/api/payments_test.go
@@ -456,7 +456,7 @@ func TestPaymentPreauthorize(t *testing.T) {
 
 			form := url.Values{}
 			form.Add("provider", payments.PayPalProvider)
-			form.Add("amount", "10")
+			form.Add("amount", "1000")
 			form.Add("currency", "USD")
 			form.Add("description", "test")
 
@@ -477,7 +477,7 @@ func TestPaymentPreauthorize(t *testing.T) {
 
 			require.Len(t, createData.Transactions, 1)
 			assert.Equal(t, "sale", createData.Intent)
-			assert.Equal(t, "10", createData.Transactions[0].Amount.Total)
+			assert.Equal(t, "10.00", createData.Transactions[0].Amount.Total)
 			assert.Equal(t, "USD", createData.Transactions[0].Amount.Currency)
 			assert.Equal(t, "test", createData.Transactions[0].Description)
 		})
@@ -492,7 +492,7 @@ func TestPaymentPreauthorize(t *testing.T) {
 			test.Config.Payment.PayPal.Env = server.URL
 
 			params := paypalPreauthorizeParams{
-				Amount:      10,
+				Amount:      1000,
 				Currency:    "USD",
 				Description: "test",
 				Provider:    payments.PayPalProvider,
@@ -518,7 +518,7 @@ func TestPaymentPreauthorize(t *testing.T) {
 
 			require.Len(t, createData.Transactions, 1)
 			assert.Equal(t, "sale", createData.Intent)
-			assert.Equal(t, "10", createData.Transactions[0].Amount.Total)
+			assert.Equal(t, "10.00", createData.Transactions[0].Amount.Total)
 			assert.Equal(t, "USD", createData.Transactions[0].Amount.Currency)
 			assert.Equal(t, "test", createData.Transactions[0].Description)
 		})

--- a/payments/paypal/paypal.go
+++ b/payments/paypal/paypal.go
@@ -123,7 +123,7 @@ func (p *paypalPaymentProvider) NewRefunder(ctx context.Context, r *http.Request
 
 func (p *paypalPaymentProvider) refund(transactionID string, amount uint64, currency string) (string, error) {
 	amt := &paypalsdk.Amount{
-		Total:    strconv.FormatUint(amount, 10),
+		Total:    formatAmount(amount),
 		Currency: currency,
 	}
 	ref, err := p.client.RefundSale(transactionID, amt)
@@ -156,7 +156,7 @@ func (p *paypalPaymentProvider) preauthorize(config *conf.Configuration, amount 
 		ExperienceProfileID: profile.ID,
 		Transactions: []paypalsdk.Transaction{paypalsdk.Transaction{
 			Amount: &paypalsdk.Amount{
-				Total:    strconv.FormatUint(amount, 10),
+				Total:    formatAmount(amount),
 				Currency: currency,
 			},
 			Description: description,
@@ -208,4 +208,8 @@ func (p *paypalPaymentProvider) getExperience() (*paypalsdk.WebProfile, error) {
 
 	p.profile = profile
 	return profile, nil
+}
+
+func formatAmount(amount uint64) string {
+	return strconv.FormatFloat(float64(amount)/100, 'f', 2, 64)
 }


### PR DESCRIPTION
This caused paypal b ased checkouts to error out based on a wrong transaction value, since we always work with amounts in cents as an integer, but paypal's API expects a string in decimal format.