### PR TITLE
Fix rounding function

### DIFF
--- a/calculator/calculator.go
+++ b/calculator/calculator.go
@@ -283,18 +283,54 @@ func calculateDiscount(amountToDiscount, taxes, percentage, fixed uint64, includ
 }
 
 // Nopes - no `round` method in go
-// See https://gist.github.com/siddontang/1806573b9a8574989ccb
-func rint(x float64) uint64 {
-	v, frac := math.Modf(x)
-	if x > 0.0 {
-		if frac > 0.5 || (frac == 0.5 && uint64(v)%2 != 0) {
-			v += 1.0
-		}
-	} else {
-		if frac < -0.5 || (frac == -0.5 && uint64(v)%2 != 0) {
-			v -= 1.0
-		}
-	}
+// See https://github.com/golang/go/blob/master/src/math/floor.go#L58
 
-	return uint64(v)
+const (
+	uvone    = 0x3FF0000000000000
+	mask     = 0x7FF
+	shift    = 64 - 11 - 1
+	bias     = 1023
+	signMask = 1 << 63
+	fracMask = 1<<shift - 1
+)
+
+// Round returns the nearest integer, rounding half away from zero.
+//
+// Special cases are:
+//	Round(±0) = ±0
+//	Round(±Inf) = ±Inf
+//	Round(NaN) = NaN
+func Round(x float64) float64 {
+	// Round is a faster implementation of:
+	//
+	// func Round(x float64) float64 {
+	//   t := Trunc(x)
+	//   if Abs(x-t) >= 0.5 {
+	//     return t + Copysign(1, x)
+	//   }
+	//   return t
+	// }
+	bits := math.Float64bits(x)
+	e := uint(bits>>shift) & mask
+	if e < bias {
+		// Round abs(x) < 1 including denormals.
+		bits &= signMask // +-0
+		if e == bias-1 {
+			bits |= uvone // +-1
+		}
+	} else if e < bias+shift {
+		// Round any abs(x) >= 1 containing a fractional component [0,1).
+		//
+		// Numbers with larger exponents are returned unchanged since they
+		// must be either an integer, infinity, or NaN.
+		const half = 1 << (shift - 1)
+		e -= bias
+		bits += half >> e
+		bits &^= fracMask >> e
+	}
+	return math.Float64frombits(bits)
+}
+
+func rint(x float64) uint64 {
+	return uint64(Round(x))
 }

--- a/calculator/calculator_test.go
+++ b/calculator/calculator_test.go
@@ -289,3 +289,48 @@ func TestMixedDiscounts(t *testing.T) {
 	price = CalculatePrice(&settings, claims, params, testLogger)
 	assert.Equal(t, int64(0), price.Total)
 }
+
+func TestRealWorldTaxCalculations(t *testing.T) {
+	settings := &Settings{
+		PricesIncludeTaxes: true,
+		Taxes: []*Tax{&Tax{
+			Percentage:   7,
+			ProductTypes: []string{"Book"},
+			Countries:    []string{"USA"},
+		}, &Tax{
+			Percentage:   19,
+			ProductTypes: []string{"E-Book"},
+			Countries:    []string{"USA"},
+		}},
+	}
+
+	item1 := &TestItem{
+		price:    2900,
+		itemType: "Book",
+		items: []Item{&TestItem{
+			price:    1900,
+			itemType: "Book",
+		}, &TestItem{
+			price:    1000,
+			itemType: "E-Book",
+		}},
+	}
+	item2 := &TestItem{
+		price:    3490,
+		itemType: "Book",
+		items: []Item{&TestItem{
+			price:    2300,
+			itemType: "Book",
+		}, &TestItem{
+			price:    1190,
+			itemType: "E-Book",
+		}},
+	}
+	params := PriceParameters{"USA", "USD", nil, []Item{item1, item2}}
+	price := CalculatePrice(settings, nil, params, testLogger)
+
+	assert.Equal(t, uint64(5766), price.Subtotal)
+	assert.Equal(t, uint64(625), price.Taxes)
+	assert.Equal(t, uint64(0), price.Discount)
+	assert.Equal(t, int64(6391), price.Total)
+}


### PR DESCRIPTION
Golang doesn't have a math.Round method yet, and so far we had been using this implementation:

https://gist.github.com/siddontang/1806573b9a8574989ccb

However, it turns out that implementation fails on 150.5 and rounds to 150 instead of 151.

This PR adds the rounding method from https://github.com/golang/go/blob/master/src/math/floor.go#L58 which seems to on the way to become a part of the std lib.