### PR TITLE
Add a public /settings endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -117,7 +117,7 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 			r.Get("/{coupon_code}", api.CouponView)
 		})
 
-		r.With(adminRequired).Get("/settings", api.ViewSettings)
+		r.Get("/settings", api.ViewSettings)
 
 		r.With(authRequired).Post("/claim", api.ClaimOrders)
 	})

--- a/calculator/calculator.go
+++ b/calculator/calculator.go
@@ -28,11 +28,25 @@ type ItemPrice struct {
 	Total    int64
 }
 
+// PaymentMethods settings
+type PaymentMethods struct {
+	Stripe struct {
+		Enabled   bool   `json:"enabled"`
+		PublicKey string `json:"public_key,omitempty"`
+	} `json:"stripe"`
+	PayPal struct {
+		Enabled     bool   `json:"enabled"`
+		ClientID    string `json:"client_id,omitempty"`
+		Environment string `json:"environment,omitempty"`
+	} `json:"paypal"`
+}
+
 // Settings represent the site-wide settings for price calculation.
 type Settings struct {
 	PricesIncludeTaxes bool              `json:"prices_include_taxes"`
-	Taxes              []*Tax            `json:"taxes"`
-	MemberDiscounts    []*MemberDiscount `json:"member_discounts"`
+	Taxes              []*Tax            `json:"taxes,omitempty"`
+	MemberDiscounts    []*MemberDiscount `json:"member_discounts,omitempty"`
+	PaymentMethods     *PaymentMethods   `json:"payment_methods,omitempty"`
 }
 
 // Tax represents a tax, potentially specific to countries and product types.

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -66,6 +66,7 @@ type Configuration struct {
 	Payment struct {
 		Stripe struct {
 			Enabled   bool   `json:"enabled"`
+			PublicKey string `json:"public_key" split_words:"true"`
 			SecretKey string `json:"secret_key" split_words:"true"`
 		} `json:"stripe"`
 		PayPal struct {


### PR DESCRIPTION
This allow client libraries easy access to public settings to detect which payment methods are enabled and access the needed public keys/ids.

