### PR TITLE
Add working Deploy to Heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ tax has been included in that product.
 
 The easiest way to use GoCommerce is with [commerce-js](https://github.com/netlify/netlify-commerce-js).
 
+## Running the GoCommerce backend
+
+GoCommerce can be deployed to any server environment that runs Go. The button below provides a quick way to get started by running on Heroku:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/netlify/gocommerce)
+
 ## Configuration
 
 You may configure GoCommerce using either a configuration file named `.env`,

--- a/app.json
+++ b/app.json
@@ -3,40 +3,23 @@
   "description": "",
   "website": "https://www.gocommerceapi.org",
   "repository": "https://github.com/netlify/gocommerce",
+  "addons": ["heroku-postgresql"],
   "env": {
     "DATABASE_URL": {},
     "GOCOMMERCE_DB_DRIVER": {
-      "value": "sqlite3"
+      "value": "postgres"
     },
     "GOCOMMERCE_DB_AUTOMIGRATE": {
       "value": true
     },
-    "GOCOMMERCE_DB_NAMESPACE": {
-      "value": "auth"
+    "GOCOMMERCE_SITE_URL": {
+      "description": "The URL for your ecommerce site",
     },
-    "GOCOMMERCE_JWT_SECRET": {
-      "required": true
+    "GOCOMMERCE_PAYMENT_STRIPE_ENABLED": {
+      "required": false
     },
-    "GOCOMMERCE_MAILER_ADMIN_EMAIL": {},
-    "GOCOMMERCE_MAILER_HOST": {},
-    "GOCOMMERCE_MAILER_MEMBER_FOLDER": {},
-    "GOCOMMERCE_MAILER_USER": {},
-    "GOCOMMERCE_MAILER_PASS": {},
-    "GOCOMMERCE_MAILER_PORT": {},
-    "GOCOMMERCE_MAILER_SITE_URL": {},
-    "GOCOMMERCE_MAILER_SUBJECTS_ORDER_CONFIRMATION": {},
-    "GOCOMMERCE_MAILER_TEMPLATES_ORDER_CONFIRMATION": {},
-    "GOCOMMERCE_COUPONS_URL": {},
-    "GOCOMMERCE_COUPONS_USER": {},
-    "GOCOMMERCE_COUPONS_PASSWORD": {},
-    "GOCOMMERCE_SITE_URL": {},
-    "GOCOMMERCE_WEBHOOKS_PAYMENT": {},
-    "GOCOMMERCE_WEBHOOKS_SECRET": {},
-    "GOCOMMERCE_PAYMENT_PAYPAL_ENABLED": {},
-    "GOCOMMERCE_PAYMENT_PAYPAL_CLIENT_ID": {},
-    "GOCOMMERCE_PAYMENT_PAYPAL_ENV": {},
-    "GOCOMMERCE_PAYMENT_PAYPAL_SECRET": {},
-    "GOCOMMERCE_PAYMENT_STRIPE_ENABLED": {},
-    "GOCOMMERCE_PAYMENT_STRIPE_SECRET": {}
+    "GOCOMMERCE_PAYMENT_STRIPE_SECRET": {
+      "required": false
+    }
   }
 }

--- a/app.json
+++ b/app.json
@@ -13,7 +13,7 @@
       "value": true
     },
     "GOCOMMERCE_SITE_URL": {
-      "description": "The URL for your ecommerce site",
+      "description": "The URL for your ecommerce site"
     },
     "GOCOMMERCE_PAYMENT_STRIPE_ENABLED": {
       "required": false

--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
       "value": "true"
     },
     "GOCOMMERCE_JWT_SECRET": {
-      "decscription": "A generated key you can use for making authenticated calls to the service",
+      "description": "A generated key you can use for making authenticated calls to the service",
       "generator": "secret"
     },
     "GOCOMMERCE_SITE_URL": {
@@ -24,31 +24,31 @@
     },
     "GOCOMMERCE_PAYMENT_STRIPE_PUBLIC_KEY": {
       "required": false,
-      "decscription": "Required if Stripe is enabled. Get this key from Stripe."
+      "description": "Required if Stripe is enabled. Get this key from Stripe."
     },
     "GOCOMMERCE_PAYMENT_STRIPE_SECRET_KEY": {
       "required": false,
-      "decscription": "Required if Stripe is enabled. Get this key from Stripe."
+      "description": "Required if Stripe is enabled. Get this key from Stripe."
     },
     "GOCOMMERCE_SMTP_HOST": {
       "required": false,
-      "decscription": "Required for sending customer emails. Get from your transactional email provider. example: smtp.sparkpost.com"
+      "description": "Required for sending customer emails. Get from your transactional email provider. example: smtp.sparkpost.com"
     },
     "GOCOMMERCE_SMTP_PORT": {
       "required": false,
-      "decscription": "Required for sending customer emails. Get this port number from your transactional email provider."
+      "description": "Required for sending customer emails. Get this port number from your transactional email provider."
     },
     "GOCOMMERCE_SMTP_USER": {
       "required": false,
-      "decscription": "Required for sending customer emails. Get this username from your transactional email provider."
+      "description": "Required for sending customer emails. Get this username from your transactional email provider."
     },
     "GOCOMMERCE_SMTP_PASS": {
       "required": false,
-      "decscription": "Required for sending customer emails. Get this password from your transactional email provider."
+      "description": "Required for sending customer emails. Get this password from your transactional email provider."
     },
     "GOCOMMERCE_SMTP_ADMIN_EMAIL": {
       "required": false,
-      "decscription": "Required for sending customer emails. This address will send customer emails and will receive order notifications."
+      "description": "Required for sending customer emails. This address will send customer emails and will receive order notifications."
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
-  "name": "Gocommerce",
-  "description": "",
+  "name": "GoCommerce",
+  "description": "A lightweight Go-based API for e-commerce sites on the JAMstack",
   "website": "https://www.gocommerceapi.org",
   "repository": "https://github.com/netlify/gocommerce",
   "addons": ["heroku-postgresql"],
@@ -11,14 +11,44 @@
     "GOCOMMERCE_DB_AUTOMIGRATE": {
       "value": "true"
     },
+    "GOCOMMERCE_JWT_SECRET": {
+      "decscription": "A generated key you can use for making authenticated calls to the service",
+      "generator": "secret"
+    },
     "GOCOMMERCE_SITE_URL": {
-      "description": "The URL for your ecommerce site"
+      "description": "The URL of the site where you will sell your products"
     },
     "GOCOMMERCE_PAYMENT_STRIPE_ENABLED": {
-      "required": false
+      "required": false,
+      "description": "Set to true to enable Stripe payment processing"
     },
-    "GOCOMMERCE_PAYMENT_STRIPE_SECRET": {
-      "required": false
+    "GOCOMMERCE_PAYMENT_STRIPE_PUBLIC_KEY": {
+      "required": false,
+      "decscription": "Required if Stripe is enabled. Get this key from Stripe."
+    },
+    "GOCOMMERCE_PAYMENT_STRIPE_SECRET_KEY": {
+      "required": false,
+      "decscription": "Required if Stripe is enabled. Get this key from Stripe."
+    },
+    "GOCOMMERCE_SMTP_HOST": {
+      "required": false,
+      "decscription": "Required for sending customer emails. Get from your transactional email provider. example: smtp.sparkpost.com"
+    },
+    "GOCOMMERCE_SMTP_PORT": {
+      "required": false,
+      "decscription": "Required for sending customer emails. Get this port number from your transactional email provider."
+    },
+    "GOCOMMERCE_SMTP_USER": {
+      "required": false,
+      "decscription": "Required for sending customer emails. Get this username from your transactional email provider."
+    },
+    "GOCOMMERCE_SMTP_PASS": {
+      "required": false,
+      "decscription": "Required for sending customer emails. Get this password from your transactional email provider."
+    },
+    "GOCOMMERCE_SMTP_ADMIN_EMAIL": {
+      "required": false,
+      "decscription": "Required for sending customer emails. This address will send customer emails and will receive order notifications."
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
       "value": "postgres"
     },
     "GOCOMMERCE_DB_AUTOMIGRATE": {
-      "value": true
+      "value": "true"
     },
     "GOCOMMERCE_SITE_URL": {
       "description": "The URL for your ecommerce site"

--- a/app.json
+++ b/app.json
@@ -5,7 +5,6 @@
   "repository": "https://github.com/netlify/gocommerce",
   "addons": ["heroku-postgresql"],
   "env": {
-    "DATABASE_URL": {},
     "GOCOMMERCE_DB_DRIVER": {
       "value": "postgres"
     },


### PR DESCRIPTION
Add the button to the readme and updates app.json so it works.

Includes:
- Automatic deployment of Heroku's Postgres DB service
- Automatic generation of the JWT secret
- Automigrate set to true
- Optional fields to add Stripe integration
- Optional fields to add mail sending
- Help text for all fields