### PR TITLE
Fix runtime panic when no payment providers are enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ release: ## Upload release to GitHub releases.
 
 
 deps: ## Install dependencies.
-	@go get -u github.com/golang/lint/golint
+	@go get -u golang.org/x/lint/golint
 	@go get -u github.com/Masterminds/glide && glide install
 
 image: ## Build the Docker image.

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -130,7 +130,7 @@ func WithInstanceConfig(ctx context.Context, smtp conf.SMTPConfiguration, config
 		return nil, errors.Wrap(err, "error creating payment providers")
 	}
 	if len(provs) == 0 {
-		return nil, errors.Wrap(err, "No payment providers enabled")
+		return nil, errors.New("No payment providers enabled")
 	}
 	ctx = gcontext.WithPaymentProviders(ctx, provs)
 

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/netlify/gocommerce/calculator"
+	"github.com/netlify/gocommerce/conf"
+	"github.com/netlify/gocommerce/models"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type MiddlewareTestSuite struct {
+	suite.Suite
+	API         *API
+	exampleSite *httptest.Server
+}
+
+func (ts *MiddlewareTestSuite) SetupTest() {
+	globalConfig, err := conf.LoadGlobal("test.env")
+	require.NoError(ts.T(), err)
+	globalConfig.MultiInstanceMode = true
+	db, err := models.Connect(globalConfig)
+	require.NoError(ts.T(), err)
+
+	api := NewAPI(globalConfig, db)
+	ts.API = api
+}
+
+func (ts *MiddlewareTestSuite) TearDownTest() {
+	if ts.exampleSite != nil {
+		ts.exampleSite.Close()
+		ts.exampleSite = nil
+	}
+
+	// Cleanup created instance
+	i, err := models.GetInstanceByUUID(ts.API.db, testUUID)
+	if err == nil {
+		require.NoError(ts.T(), models.DeleteInstance(ts.API.db, i))
+	}
+}
+
+func (ts *MiddlewareTestSuite) setupInstance(config *conf.Configuration, siteSettings interface{}) string {
+	if config == nil {
+		_, config = testConfig()
+	}
+
+	if siteSettings == nil {
+		siteSettings = struct{}{}
+	}
+	ts.exampleSite = startTestSiteWithSettings(siteSettings)
+	config.SiteURL = ts.exampleSite.URL
+
+	instanceID := uuid.NewRandom().String()
+	err := models.CreateInstance(ts.API.db, &models.Instance{
+		ID:         instanceID,
+		UUID:       testUUID,
+		BaseConfig: config,
+	})
+	require.NoError(ts.T(), err)
+
+	return instanceID
+}
+
+func (ts *MiddlewareTestSuite) TestWithInstanceConfig() {
+	instanceID := ts.setupInstance(nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/settings", nil)
+	req.Header.Set("Content-Type", "application/json")
+	err := signInstanceRequest(req, instanceID, ts.API.config.OperatorToken)
+	require.NoError(ts.T(), err)
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusOK, w.Code)
+
+	settingsPayload := &calculator.Settings{
+		PricesIncludeTaxes: false,
+		PaymentMethods:     &calculator.PaymentMethods{},
+	}
+	settingsPayload.PaymentMethods.Stripe.Enabled = true
+
+	parsedBody := &calculator.Settings{}
+	err = json.NewDecoder(w.Body).Decode(parsedBody)
+	require.NoError(ts.T(), err)
+
+	require.EqualValues(ts.T(), settingsPayload, parsedBody)
+}
+
+func (ts *MiddlewareTestSuite) TestWithInstanceConfig_NoPaymentProviders() {
+	instanceID := ts.setupInstance(&conf.Configuration{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/settings", nil)
+	req.Header.Set("Content-Type", "application/json")
+	err := signInstanceRequest(req, instanceID, ts.API.config.OperatorToken)
+	require.NoError(ts.T(), err)
+
+	w := httptest.NewRecorder()
+	ts.API.handler.ServeHTTP(w, req)
+	require.Equal(ts.T(), http.StatusInternalServerError, w.Code)
+}
+
+func TestMiddleware(t *testing.T) {
+	suite.Run(t, new(MiddlewareTestSuite))
+}

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -364,3 +364,33 @@ func signHTTPRequest(req *http.Request, token *jwt.Token, jwtSecret string) erro
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tokenStr))
 	return nil
 }
+
+func signInstanceRequest(req *http.Request, instanceID string, jwtSecret string) error {
+	claims := &NetlifyMicroserviceClaims{
+		InstanceID: instanceID,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	jwt, err := token.SignedString([]byte(jwtSecret))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("x-nf-sign", jwt)
+	return nil
+}
+
+// ------------------------------------------------------------------------------------------------
+// TEST SITE
+// ------------------------------------------------------------------------------------------------
+func startTestSiteWithSettings(settings interface{}) *httptest.Server {
+	settingsStr, err := json.Marshal(settings)
+	if err != nil {
+		panic(fmt.Errorf("Encoding the settings failed: %+v", err))
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/gocommerce/settings.json":
+			w.Write(settingsStr)
+		}
+	}))
+}


### PR DESCRIPTION
**- Summary**

When there are no payment providers enabled, the process starts up fine, but will panic on a call to any instance specific endpoint.

My commit fixes this by not wrongly returning nil for the error.

**- Test plan**

Included are the following test:
- Initial e2e test for `WithInstanceConfig` in context of calling `/settings`
- Regression test for `WithInstanceConfig` modeling the case when no payment providers are enabled

**- Description for the changelog**

Fixed a bug in multi-instance mode when no payment methods are configured.

**- A picture of a cute animal (not mandatory but encouraged)**

<img src="https://user-images.githubusercontent.com/4941459/46878034-df0ef000-ce4a-11e8-80ae-0918884038c3.jpg" width="200"/>
