### PR TITLE
Fix path to install golint from

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ release: ## Upload release to GitHub releases.
 
 
 deps: ## Install dependencies.
-	@go get -u github.com/golang/lint/golint
+	@go get -u golang.org/x/lint/golint
 	@go get -u github.com/Masterminds/glide && glide install
 
 image: ## Build the Docker image.


### PR DESCRIPTION
Apparently due to https://github.com/golang/lint/commit/9a272034dedb2a3ed05231d5604ce17fb40f0e58 `go get` now rejects installing via the github mirror.