### PR TITLE
Fix pagination for user listing

### DIFF
--- a/api/order_test.go
+++ b/api/order_test.go
@@ -226,6 +226,17 @@ func TestOrdersList(t *testing.T) {
 			assert.Len(t, orders, 1)
 		})
 	})
+	t.Run("Pagination", func(t *testing.T) {
+		test := NewRouteTest(t)
+		token := test.Data.testUserToken
+		reqUrl := "/orders?per_page=1"
+		recorder := test.TestEndpoint(http.MethodGet, reqUrl, nil, token)
+
+		orders := []models.Order{}
+		extractPayload(t, http.StatusOK, recorder, &orders)
+		assert.Len(t, orders, 1)
+		validatePagination(t, recorder, reqUrl, 2, 1, 1, 2)
+	})
 }
 
 func TestUserOrdersList(t *testing.T) {

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -21,7 +21,7 @@ func calculateTotalPages(perPage, total uint64) uint64 {
 
 func addPaginationHeaders(w http.ResponseWriter, r *http.Request, page, perPage, total uint64) {
 	totalPages := calculateTotalPages(perPage, total)
-	url, _ := url.ParseRequestURI(r.URL.String())
+	url, _ := url.ParseRequestURI(r.URL.RequestURI())
 	query := url.Query()
 	header := ""
 	if totalPages > page {

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -67,6 +67,19 @@ func TestUsersList(t *testing.T) {
 		require.Len(t, users, 1)
 		assert.Equal(t, "villian", users[0].ID)
 	})
+	t.Run("WithPagination", func(t *testing.T) {
+		test, _, rollback := createSecondUser(t)
+		defer rollback()
+
+		token := testAdminToken("magical-unicorn", "")
+		reqUrl := "/users?per_page=1"
+		recorder := test.TestEndpoint(http.MethodGet, reqUrl, nil, token)
+
+		users := []models.User{}
+		extractPayload(t, http.StatusOK, recorder, &users)
+		require.Len(t, users, 1)
+		validatePagination(t, recorder, reqUrl, 2, 1, 1, 2)
+	})
 }
 
 func TestUsersView(t *testing.T) {

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -252,9 +252,6 @@ func loadTestData(t *testing.T, db *gorm.DB) *TestData {
 	require.NoError(t, db.Create(testData.firstLineItem).Error)
 	require.NoError(t, db.Create(testData.firstOrder).Error)
 	require.NoError(t, db.Create(testData.firstTransaction).Error)
-	for _, d := range testData.firstOrder.Downloads {
-		require.NoError(t, db.Create(d).Error)
-	}
 
 	require.NoError(t, db.Create(testData.secondLineItem1).Error)
 	require.NoError(t, db.Create(testData.secondLineItem2).Error)

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -8,7 +8,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -313,6 +315,28 @@ func validateAddress(t *testing.T, expected models.Address, actual models.Addres
 	assert.Equal(expected.Country, actual.Country)
 	assert.Equal(expected.State, actual.State)
 	assert.Equal(expected.Zip, actual.Zip)
+}
+
+func validatePagination(t *testing.T, r *httptest.ResponseRecorder, reqUrl string, total int, page int, perPage int, totalPages int) {
+	assert := assert.New(t)
+
+	// build expected link header
+	linkHeader := ""
+	url, err := url.ParseRequestURI(reqUrl)
+	assert.NoError(err)
+	query := url.Query()
+	if totalPages > page {
+		query.Set("page", fmt.Sprintf("%v", page+1))
+		url.RawQuery = query.Encode()
+		linkHeader += "<" + url.String() + ">; rel=\"next\", "
+	}
+	query.Set("page", fmt.Sprintf("%v", totalPages))
+	url.RawQuery = query.Encode()
+	linkHeader += "<" + url.String() + ">; rel=\"last\""
+
+	headers := r.HeaderMap
+	assert.Equal(strconv.Itoa(total), headers["X-Total-Count"][0])
+	assert.Equal(linkHeader, headers["Link"][0])
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 412c7bbcd6147beb7f635ab387e50d19f377d4e5bb19f2a279a80222685c74cc
-updated: 2018-06-14T11:41:55.777808-04:00
+hash: 5c323ab6120aa0196280c039ea80bc8f21a76f34c6880c47935603b6eff9cc8d
+updated: 2018-10-18T17:14:54.331248849+02:00
 imports:
 - name: cloud.google.com/go
   version: 98f5696b1026056a47f114c4451dbc4703d67191
@@ -46,7 +46,7 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jinzhu/gorm
-  version: 5174cc5c242a728b435ea2be8a2f7f998e15429b
+  version: 6ed508ec6a4ecb3531899a69cbc746ccf65a4166
 - name: github.com/jinzhu/inflection
   version: 1c35d901db3da928c72a72d8458480cc9ade058f
 - name: github.com/joho/godotenv

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,6 +6,7 @@ import:
 - package: github.com/go-sql-driver/mysql
   version: v1.3
 - package: github.com/jinzhu/gorm
+  version: v1.9.1
 - package: github.com/lib/pq
 - package: github.com/mattn/go-sqlite3
   version: v1.1.0


### PR DESCRIPTION
Fixes #122

**- Summary**

There was an issue with counting total records in queries with joins / groups. An update of Gorm fixed this.
Since the tests are actually not mocking gorm, I am confident that the upgrade will not break anything.

**- Test plan**

I added tests for verifying the pagination headers for *user* and *order* endpoints.

**- Description for the changelog**

Fix pagination on user listing endpoint