### PR TITLE
Show timestamp of most recent order for users

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -61,7 +61,10 @@ func (a *API) UserList(w http.ResponseWriter, r *http.Request) error {
 		return badRequestError("Bad Pagination Parameters: %v", err)
 	}
 
-	query = query.Select("count(" + orderTable + ".id) as order_count, " + userTable + ".*")
+	query = query.Select("" +
+		"COUNT(" + orderTable + ".id) AS order_count, " +
+		"MAX(" + orderTable + ".created_at) AS last_order_at, " +
+		userTable + ".*")
 
 	users := []models.User{}
 	if err := query.Offset(offset).Limit(limit).Find(&users).Error; err != nil {

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -48,8 +50,11 @@ func TestUsersList(t *testing.T) {
 			switch u.ID {
 			case toDie.ID:
 				assert.Equal(t, "twoface@dc.com", u.Email)
+				assert.Nil(t, u.LastOrderAt)
 			case test.Data.testUser.ID:
 				assert.Equal(t, test.Data.testUser.Email, u.Email)
+				expectedTime := mysql.NullTime{test.Data.secondOrder.CreatedAt.In(time.UTC), true}
+				assert.EqualValues(t, expectedTime, *u.LastOrderAt)
 			default:
 				assert.Fail(t, "unexpected user %v\n", u)
 			}

--- a/models/user.go
+++ b/models/user.go
@@ -18,7 +18,7 @@ type User struct {
 	UpdatedAt time.Time  `json:"updated_at"`
 	DeletedAt *time.Time `json:"-"`
 
-	OrderCount int64 `json:"order_count,ommitempty" gorm:"-"`
+	OrderCount int64 `json:"order_count" gorm:"-"`
 }
 
 // TableName returns the database table name for the User model.

--- a/models/user.go
+++ b/models/user.go
@@ -1,9 +1,11 @@
 package models
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 )
@@ -18,7 +20,63 @@ type User struct {
 	UpdatedAt time.Time  `json:"updated_at"`
 	DeletedAt *time.Time `json:"-"`
 
-	OrderCount int64 `json:"order_count" gorm:"-"`
+	OrderCount  int64          `json:"order_count" gorm:"-"`
+	LastOrderAt *HackyNullTime `json:"last_order_at" gorm:"-"`
+}
+
+// @todo: replace with mysql.NullTime once the tests no longer use SQLite
+type HackyNullTime struct {
+	Time  time.Time
+	Valid bool
+}
+
+func (t *HackyNullTime) Scan(value interface{}) (err error) {
+	if value == nil {
+		t.Valid = false
+		return nil
+	}
+
+	// try parsing with mysql time format
+	var parsingTime mysql.NullTime
+	if err := parsingTime.Scan(value); err == nil {
+		t.Time = parsingTime.Time
+		t.Valid = parsingTime.Valid
+		return nil
+	}
+
+	// fallback to sqlite time format
+	timeFormat := "2006-01-02 15:04:05.999999999"
+
+	switch v := value.(type) {
+	case []byte:
+		t.Time, err = time.Parse(timeFormat, string(v))
+		t.Valid = (err == nil)
+	case string:
+		t.Time, err = time.Parse(timeFormat, v)
+		t.Valid = (err == nil)
+	}
+
+	return nil
+}
+
+func (t *HackyNullTime) MarshalJSON() ([]byte, error) {
+	if !t.Valid {
+		return json.Marshal(nil)
+	}
+
+	return json.Marshal(t.Time)
+}
+
+func (t *HackyNullTime) UnmarshalJSON(data []byte) error {
+	time := time.Time{}
+	err := time.UnmarshalJSON(data)
+	if err == nil && !time.IsZero() {
+		t.Valid = true
+		t.Time = time
+		return nil
+	}
+	t.Valid = false
+	return nil
 }
 
 // TableName returns the database table name for the User model.


### PR DESCRIPTION
Fixes #121 

**- Summary**

For every user object in the user listing this will add a timestamp of the creation of the most recent order for that user.

The issue actually mentions a field with the id of the most recent order. This is actually really complex in terms of the current query that is used and doing `MAX(orders.created_at)` seemed more straight-forward since the frontend design for `gocommerce-admin`  shows a timestamp.

@RoseannaM can you tell me if this is sufficient?

If we need to be able to link to the most recent order in the frontend, I can come back to this and figure out a good way to provide the ID, too.

**- Test plan**

An assertion for the `LastOrderAt` field has been added in the user listing test.

**- Description for the changelog**

Provide a timestamp of the most recent order in the user listing