### PR TITLE
Persist username from JWT or order

### DIFF
--- a/api/order.go
+++ b/api/order.go
@@ -377,6 +377,11 @@ func (a *API) OrderCreate(w http.ResponseWriter, r *http.Request) error {
 		order.BillingAddressID = shipping.ID
 	}
 
+	if httpError := persistUserName(tx, order, claims); httpError != nil {
+		tx.Rollback()
+		return httpError
+	}
+
 	if params.VATNumber != "" {
 		valid, err := vat.IsValidVAT(params.VATNumber)
 		if err != nil {

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -20,6 +20,7 @@ func createSecondUser(t *testing.T) (*RouteTest, models.User, func()) {
 	toDie := models.User{
 		ID:    "villian",
 		Email: "twoface@dc.com",
+		Name:  "Harvey Dent",
 	}
 	rsp := test.DB.Create(&toDie)
 	require.NoError(t, rsp.Error, "DB Error")
@@ -50,9 +51,11 @@ func TestUsersList(t *testing.T) {
 			switch u.ID {
 			case toDie.ID:
 				assert.Equal(t, "twoface@dc.com", u.Email)
+				assert.Equal(t, "Harvey Dent", u.Name)
 				assert.Nil(t, u.LastOrderAt)
 			case test.Data.testUser.ID:
 				assert.Equal(t, test.Data.testUser.Email, u.Email)
+				assert.Equal(t, "Bruce Wayne", u.Name)
 				expectedTime := mysql.NullTime{test.Data.secondOrder.CreatedAt.In(time.UTC), true}
 				assert.EqualValues(t, expectedTime, *u.LastOrderAt)
 			default:

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -77,12 +78,23 @@ func testConfig() (*conf.GlobalConfiguration, *conf.Configuration) {
 	return globalConfig, config
 }
 
-func testToken(id, email string) *jwt.Token {
+func testToken(args ...string) *jwt.Token {
+	if len(args) < 2 {
+		panic(errors.New("Missing parameter to testToken()"))
+	}
+	id := args[0]
+	email := args[1]
 	claims := &claims.JWTClaims{
 		StandardClaims: jwt.StandardClaims{
 			Subject: id,
 		},
 		Email: email,
+	}
+
+	if len(args) > 2 {
+		claims.UserMetaData = map[string]interface{}{
+			"full_name": args[2],
+		}
 	}
 	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 }
@@ -137,6 +149,7 @@ func setupTestData() *TestData {
 	testUser := &models.User{
 		ID:    "i-am-batman",
 		Email: "bruce@wayneindustries.com",
+		Name:  "Bruce Wayne",
 	}
 
 	testAddress := models.Address{

--- a/models/user.go
+++ b/models/user.go
@@ -15,6 +15,7 @@ type User struct {
 	InstanceID string `json:"-"`
 	ID         string `json:"id"`
 	Email      string `json:"email"`
+	Name       string `json:"name"`
 
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`


### PR DESCRIPTION
Fixes #120

**- Summary**

When a order is made while a user is logged in (JWT passed along) and it is their first order, a new user object will be created in gocommerce.

This PR introduces a new field for the user object: `name`
It will be set only on creation of the user.

In order to determine the user's name, the following fields are considered in this order:
- `UserMetadata["full_name"]` from JWT claims *(this is what the Identity Widget uses)*
- `BillingAddress.Name` from order
- `ShippingAddress.Name` from order

**- Test plan**

I created a test suite covering the creation of a user on their first order.
It also verifies the name field in the different cases.

**- Description for the changelog**

Persist user's name from JWT or order on their first order