### PR TITLE
Upgrade go in TravisCI to version 1.9 to fix the install of golint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: go
 
 go:
-  - 1.8
+  - "1.9"
 
 install: make deps
 script: make all


### PR DESCRIPTION
**- Summary**

Travis was using Go 1.8 for testing and it seems like golint is not working for Go 1.8 anymore, at least temporarily.
I decided the upgrade would be a good thing to do. We should also consider upgrading higher soon.

**- Description for the changelog**

Fix CI build by using go 1.9