### PR TITLE
Report number of orders for each currency on sales report

### DIFF
--- a/api/reports.go
+++ b/api/reports.go
@@ -12,6 +12,7 @@ type salesRow struct {
 	SubTotal uint64 `json:"subtotal"`
 	Taxes    uint64 `json:"taxes"`
 	Currency string `json:"currency"`
+	Orders   uint64 `json:"orders"`
 }
 
 type productsRow struct {
@@ -27,7 +28,7 @@ func (a *API) SalesReport(w http.ResponseWriter, r *http.Request) error {
 
 	query := a.db.
 		Model(&models.Order{}).
-		Select("sum(total) as total, sum(sub_total) as subtotal, sum(taxes) as taxes, currency").
+		Select("sum(total) as total, sum(sub_total) as subtotal, sum(taxes) as taxes, currency, count(*) as orders").
 		Where("payment_state = 'paid' AND instance_id = ?", instanceID).
 		Group("currency")
 
@@ -44,7 +45,7 @@ func (a *API) SalesReport(w http.ResponseWriter, r *http.Request) error {
 	result := []*salesRow{}
 	for rows.Next() {
 		row := &salesRow{}
-		err = rows.Scan(&row.Total, &row.SubTotal, &row.Taxes, &row.Currency)
+		err = rows.Scan(&row.Total, &row.SubTotal, &row.Taxes, &row.Currency, &row.Orders)
 		if err != nil {
 			return internalServerError("Database error").WithInternalError(err)
 		}

--- a/api/reports_test.go
+++ b/api/reports_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSalesReport(t *testing.T) {
+	t.Run("AllTime", func(t *testing.T) {
+		test := NewRouteTest(t)
+		token := testAdminToken("admin-yo", "admin@wayneindustries.com")
+		recorder := test.TestEndpoint(http.MethodGet, "/reports/sales", nil, token)
+
+		report := []salesRow{}
+		extractPayload(t, http.StatusOK, recorder, &report)
+		assert.Len(t, report, 1)
+		row := report[0]
+		assert.Equal(t, uint64(79), row.Total)
+		assert.Equal(t, uint64(79), row.SubTotal)
+		assert.Equal(t, uint64(0), row.Taxes)
+		assert.Equal(t, "USD", row.Currency)
+		assert.Equal(t, uint64(2), row.Orders)
+	})
+}


### PR DESCRIPTION
Fixes #135

**- Summary**

The sales reports endpoint should contain the number of orders to be able to calculate averages.

**- Test plan**

Added a test for the sales report endpoint

**- Description for the changelog**

Report number of orders for each currency on sales report

**- A picture of a cute animal (not mandatory but encouraged)**

![otter-basketball](https://user-images.githubusercontent.com/4941459/47506536-91de4580-d870-11e8-9d20-3b4f24e11c1f.gif)
