### PR TITLE
Allow deletion of multiple users

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -174,6 +174,7 @@ func (a *API) orderRoutes(r *router) {
 func (a *API) userRoutes(r *router) {
 	r.Use(authRequired)
 	r.With(adminRequired).Get("/", a.UserList)
+	r.With(adminRequired).Delete("/", a.UserBulkDelete)
 
 	r.Route("/{user_id}", func(r *router) {
 		r.Use(a.withUser)

--- a/api/params.go
+++ b/api/params.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jinzhu/gorm"
 	"github.com/netlify/gocommerce/models"
+	"github.com/pkg/errors"
 )
 
 type sortDirection string
@@ -49,6 +50,18 @@ func parsePaymentQueryParams(query *gorm.DB, params url.Values) (*gorm.DB, error
 		return nil, err
 	}
 	return parseTimeQueryParams(query, params)
+}
+
+func parseUserBulkDeleteParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {
+	if _, ok := params["id"]; !ok {
+		return nil, errors.New("User ID field is required")
+	}
+
+	userTable := query.NewScope(models.User{}).QuotedTableName()
+	query = addFilters(query, userTable, params, []string{
+		"id",
+	})
+	return query, nil
 }
 
 func parseUserQueryParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {

--- a/api/params.go
+++ b/api/params.go
@@ -207,7 +207,7 @@ func parseTimeQueryParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {
 func addFilters(query *gorm.DB, table string, params url.Values, availableFilters []string) *gorm.DB {
 	for _, filter := range availableFilters {
 		if values, exists := params[filter]; exists {
-			query = query.Where(table+"."+filter+" = ?", values[0])
+			query = query.Where(table+"."+filter+" IN (?)", values)
 		}
 	}
 	return query


### PR DESCRIPTION
Fixes #136 

**- Summary**

In order to delete multiple users issue a `DELETE` call to `/users`.
Multiple `id` query parameters will determine which users should be deleted.

Example:
```
DELETE /users?id=user1&id=user2&id=user3
```

This is the closest you get to implementing bulk deletion in REST.
It should also be compatible to how [qs (js lib)](https://www.npmjs.com/package/qs) handles a parameter with multiple values. (Use `{ indices: false }` in the options.)

*This action is meant to be idempotent:*
If you pass ids which don't exist it will not result in an error. This enables sending the same request multiple times if the first request failed and only some users got deleted. Although internally it uses a transaction to rollback changes if one delete fails, idempotency is still a best practice for this.

**- Test plan**

There is a new test suite `TestUserBulkDelete` with 5 different test cases.

**- Description for the changelog**

Allow deletion of multiple users