### PR TITLE
Implement filtering by state for order list

### DIFF
--- a/api/order_test.go
+++ b/api/order_test.go
@@ -19,16 +19,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createOrder(test *RouteTest, email, currency string) (*models.Order, func()) {
-	t := test.T
-
+func createOrder(test *RouteTest, email, currency string) *models.Order {
 	order := models.NewOrder("", "session1", email, currency)
 	result := test.DB.Create(order)
-	assert.NoError(t, result.Error, fmt.Sprintf("inserting the test order failed: %+v", result.Error))
+	assert.NoError(test.T, result.Error, fmt.Sprintf("inserting the test order failed: %+v", result.Error))
 
-	return order, func() {
-		test.DB.Unscoped().Delete(&order)
-	}
+	return order
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -344,8 +340,7 @@ func TestUserOrdersList(t *testing.T) {
 		t.Run("PaymentStatePending", func(t *testing.T) {
 			test := NewRouteTest(t)
 
-			pendingOrder, rollback := createOrder(test, "fanboy@wayneindustries.com", "USD")
-			defer rollback()
+			pendingOrder := createOrder(test, "fanboy@wayneindustries.com", "USD")
 			pendingOrder.PaymentState = models.PendingState
 			test.DB.Save(&pendingOrder)
 
@@ -362,8 +357,7 @@ func TestUserOrdersList(t *testing.T) {
 		t.Run("PaymentStatePaid", func(t *testing.T) {
 			test := NewRouteTest(t)
 
-			pendingOrder, rollback := createOrder(test, "fanboy@wayneindustries.com", "USD")
-			defer rollback()
+			pendingOrder := createOrder(test, "fanboy@wayneindustries.com", "USD")
 			pendingOrder.PaymentState = models.PendingState
 			test.DB.Save(&pendingOrder)
 
@@ -393,8 +387,7 @@ func TestUserOrdersList(t *testing.T) {
 		t.Run("FulfillmentStatePending", func(t *testing.T) {
 			test := NewRouteTest(t)
 
-			shippedOrder, rollback := createOrder(test, "fanboy@wayneindustries.com", "USD")
-			defer rollback()
+			shippedOrder := createOrder(test, "fanboy@wayneindustries.com", "USD")
 			shippedOrder.FulfillmentState = models.ShippedState
 			test.DB.Save(&shippedOrder)
 
@@ -409,8 +402,7 @@ func TestUserOrdersList(t *testing.T) {
 		t.Run("FulfillmentStateShipped", func(t *testing.T) {
 			test := NewRouteTest(t)
 
-			shippedOrder, rollback := createOrder(test, "fanboy@wayneindustries.com", "USD")
-			defer rollback()
+			shippedOrder := createOrder(test, "fanboy@wayneindustries.com", "USD")
 			shippedOrder.FulfillmentState = models.ShippedState
 			test.DB.Save(&shippedOrder)
 

--- a/api/order_test.go
+++ b/api/order_test.go
@@ -19,6 +19,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func createOrder(test *RouteTest, email, currency string) (*models.Order, func()) {
+	t := test.T
+
+	order := models.NewOrder("", "session1", email, currency)
+	result := test.DB.Create(order)
+	assert.NoError(t, result.Error, fmt.Sprintf("inserting the test order failed: %+v", result.Error))
+
+	return order, func() {
+		test.DB.Unscoped().Delete(&order)
+	}
+}
+
 // ------------------------------------------------------------------------------------------------
 // CREATE
 // ------------------------------------------------------------------------------------------------
@@ -327,6 +339,97 @@ func TestUserOrdersList(t *testing.T) {
 		extractPayload(t, http.StatusOK, recorder, &orders)
 		assert.Len(t, orders, 2)
 		validateAllOrders(t, orders, test.Data)
+	})
+	t.Run("AllOrdersFilter", func(t *testing.T) {
+		t.Run("PaymentStatePending", func(t *testing.T) {
+			test := NewRouteTest(t)
+
+			pendingOrder, rollback := createOrder(test, "fanboy@wayneindustries.com", "USD")
+			defer rollback()
+			pendingOrder.PaymentState = models.PendingState
+			test.DB.Save(&pendingOrder)
+
+			token := testAdminToken("admin-yo", "admin@wayneindustries.com")
+			recorder := test.TestEndpoint(http.MethodGet, "/users/all/orders?payment_state=pending", nil, token)
+
+			orders := []models.Order{}
+			extractPayload(t, http.StatusOK, recorder, &orders)
+			assert.Len(t, orders, 1)
+			singleOrder := orders[0]
+			assert.Equal(t, pendingOrder.ID, singleOrder.ID)
+			assert.Equal(t, "fanboy@wayneindustries.com", singleOrder.Email)
+		})
+		t.Run("PaymentStatePaid", func(t *testing.T) {
+			test := NewRouteTest(t)
+
+			pendingOrder, rollback := createOrder(test, "fanboy@wayneindustries.com", "USD")
+			defer rollback()
+			pendingOrder.PaymentState = models.PendingState
+			test.DB.Save(&pendingOrder)
+
+			token := testAdminToken("admin-yo", "admin@wayneindustries.com")
+			recorder := test.TestEndpoint(http.MethodGet, "/users/all/orders?payment_state=paid", nil, token)
+
+			orders := []models.Order{}
+			extractPayload(t, http.StatusOK, recorder, &orders)
+			assert.Len(t, orders, 2)
+			validateAllOrders(t, orders, test.Data)
+		})
+		t.Run("PaymentStateFailed", func(t *testing.T) {
+			test := NewRouteTest(t)
+			token := testAdminToken("admin-yo", "admin@wayneindustries.com")
+			recorder := test.TestEndpoint(http.MethodGet, "/users/all/orders?payment_state=failed", nil, token)
+
+			orders := []models.Order{}
+			extractPayload(t, http.StatusOK, recorder, &orders)
+			assert.Len(t, orders, 0)
+		})
+		t.Run("PaymentStateInvalid", func(t *testing.T) {
+			test := NewRouteTest(t)
+			token := testAdminToken("admin-yo", "admin@wayneindustries.com")
+			recorder := test.TestEndpoint(http.MethodGet, "/users/all/orders?payment_state=stolen", nil, token)
+			validateError(t, http.StatusBadRequest, recorder)
+		})
+		t.Run("FulfillmentStatePending", func(t *testing.T) {
+			test := NewRouteTest(t)
+
+			shippedOrder, rollback := createOrder(test, "fanboy@wayneindustries.com", "USD")
+			defer rollback()
+			shippedOrder.FulfillmentState = models.ShippedState
+			test.DB.Save(&shippedOrder)
+
+			token := testAdminToken("admin-yo", "admin@wayneindustries.com")
+			recorder := test.TestEndpoint(http.MethodGet, "/users/all/orders?fulfillment_state=pending", nil, token)
+
+			orders := []models.Order{}
+			extractPayload(t, http.StatusOK, recorder, &orders)
+			assert.Len(t, orders, 2)
+			validateAllOrders(t, orders, test.Data)
+		})
+		t.Run("FulfillmentStateShipped", func(t *testing.T) {
+			test := NewRouteTest(t)
+
+			shippedOrder, rollback := createOrder(test, "fanboy@wayneindustries.com", "USD")
+			defer rollback()
+			shippedOrder.FulfillmentState = models.ShippedState
+			test.DB.Save(&shippedOrder)
+
+			token := testAdminToken("admin-yo", "admin@wayneindustries.com")
+			recorder := test.TestEndpoint(http.MethodGet, "/users/all/orders?fulfillment_state=shipped", nil, token)
+
+			orders := []models.Order{}
+			extractPayload(t, http.StatusOK, recorder, &orders)
+			assert.Len(t, orders, 1)
+			singleOrder := orders[0]
+			assert.Equal(t, shippedOrder.ID, singleOrder.ID)
+			assert.Equal(t, "fanboy@wayneindustries.com", singleOrder.Email)
+		})
+		t.Run("FulfillmentStateInvalid", func(t *testing.T) {
+			test := NewRouteTest(t)
+			token := testAdminToken("admin-yo", "admin@wayneindustries.com")
+			recorder := test.TestEndpoint(http.MethodGet, "/users/all/orders?fulfillment_state=sunken", nil, token)
+			validateError(t, http.StatusBadRequest, recorder)
+		})
 	})
 	t.Run("NotWithAdminRights", func(t *testing.T) {
 		test := NewRouteTest(t)

--- a/models/order.go
+++ b/models/order.go
@@ -24,6 +24,20 @@ const ShippedState = "shipped"
 // FailedState is the failed state of an Order
 const FailedState = "failed"
 
+// PaymentState are the possible values for the PaymentState field
+var PaymentStates = []string{
+	PendingState,
+	PaidState,
+	FailedState,
+}
+
+// FulfillmentStates are the possible values for the FulfillmentState field
+var FulfillmentStates = []string{
+	PendingState,
+	ShippedState,
+	FailedState,
+}
+
 // NumberType | StringType | BoolType are the different types supported in custom data for orders
 const (
 	NumberType = iota


### PR DESCRIPTION
Fixes #119
Regards #137

**- Summary**

With this change, orders can be filtered by `payment_state` and `fulfillment_state`.

These values are allowed:
- for `payment_state`
  - `pending`
  - `paid`
  - `failed`
- for `fulfillment_state`
  - `pending`
  - `shipped`
  - `failed`

**- Test plan**

There are now several filtering tests inside the `TestUserOrdersList` suite.

**- Description for the changelog**

Implement filtering by payment and fulfillment state for order list