### PR TITLE
Refactor tests globally to not rollback db changes manually

### DIFF
--- a/api/order_test.go
+++ b/api/order_test.go
@@ -149,7 +149,6 @@ func TestOrderCreateNewUser(t *testing.T) {
 		body := strings.NewReader(defaultPayload)
 
 		token := testToken(firstTimeUser.ID, firstTimeUser.Email)
-		defer test.DB.Delete(firstTimeUser)
 
 		recorder := test.TestEndpoint(http.MethodPost, "/orders", body, token)
 
@@ -167,7 +166,6 @@ func TestOrderCreateNewUser(t *testing.T) {
 		body := strings.NewReader(defaultPayload)
 
 		token := testToken(firstTimeUser.ID, firstTimeUser.Email, firstTimeUser.Name)
-		defer test.DB.Delete(firstTimeUser)
 
 		recorder := test.TestEndpoint(http.MethodPost, "/orders", body, token)
 
@@ -199,7 +197,6 @@ func TestOrderCreateNewUser(t *testing.T) {
 		body := strings.NewReader(payloadWithBilling)
 
 		token := testToken(firstTimeUser.ID, firstTimeUser.Email)
-		defer test.DB.Delete(firstTimeUser)
 
 		recorder := test.TestEndpoint(http.MethodPost, "/orders", body, token)
 
@@ -508,7 +505,6 @@ func TestOrderUpdate(t *testing.T) {
 		}
 		token := testAdminToken("admin-yo", "admin@wayneindustries.com")
 		recorder := runOrderUpdate(test, test.Data.firstOrder, op, token)
-		defer test.DB.Save(test.Data.firstOrder)
 
 		assert := assert.New(t)
 		rspOrder := new(models.Order)
@@ -538,14 +534,12 @@ func TestOrderUpdate(t *testing.T) {
 		newAddr.ID = "new-addr"
 		newAddr.UserID = test.Data.firstOrder.UserID
 		test.DB.Create(newAddr)
-		defer test.DB.Unscoped().Delete(newAddr)
 
 		op := &orderRequestParams{
 			BillingAddressID: newAddr.ID,
 		}
 		token := testAdminToken("admin-yo", "admin@wayneindustries.com")
 		recorder := runOrderUpdate(test, test.Data.firstOrder, op, token)
-		defer test.DB.Save(test.Data.firstOrder)
 
 		rspOrder := new(models.Order)
 		extractPayload(t, http.StatusOK, recorder, rspOrder)
@@ -560,7 +554,6 @@ func TestOrderUpdate(t *testing.T) {
 		savedAddr := &models.Address{ID: saved.BillingAddressID}
 		rsp = test.DB.First(savedAddr)
 		require.False(t, rsp.RecordNotFound())
-		defer test.DB.Unscoped().Delete(savedAddr)
 
 		validateAddress(t, *newAddr, *savedAddr)
 	})
@@ -574,7 +567,6 @@ func TestOrderUpdate(t *testing.T) {
 		}
 		token := testAdminToken("admin-yo", "admin@wayneindustries.com")
 		recorder := runOrderUpdate(test, test.Data.firstOrder, op, token)
-		defer test.DB.Save(test.Data.firstOrder)
 
 		rspOrder := new(models.Order)
 		extractPayload(t, http.StatusOK, recorder, rspOrder)
@@ -589,7 +581,6 @@ func TestOrderUpdate(t *testing.T) {
 		savedAddr := &models.Address{ID: saved.ShippingAddressID}
 		rsp = test.DB.First(savedAddr)
 		require.False(t, rsp.RecordNotFound())
-		defer test.DB.Unscoped().Delete(savedAddr)
 
 		validateAddress(t, *paramsAddress, *savedAddr)
 	})
@@ -627,7 +618,6 @@ func TestOrderUpdate(t *testing.T) {
 		}
 		token := testAdminToken("admin-yo", "admin@wayneindustries.com")
 		recorder := runOrderUpdate(test, test.Data.firstOrder, op, token)
-		defer test.DB.Save(test.Data.firstOrder)
 
 		order := &models.Order{}
 		extractPayload(t, http.StatusOK, recorder, order)

--- a/api/payments_test.go
+++ b/api/payments_test.go
@@ -47,7 +47,6 @@ func TestOrderPaymentsList(t *testing.T) {
 		test := NewRouteTest(t)
 		anotherTransaction := models.NewTransaction(test.Data.firstOrder)
 		test.DB.Create(anotherTransaction)
-		defer test.DB.Unscoped().Delete(anotherTransaction)
 
 		token := testAdminToken("magical-unicorn", "")
 		recorder := test.TestEndpoint(http.MethodGet, test.Data.urlForFirstOrder+"/payments", nil, token)


### PR DESCRIPTION
**- Summary**

This removes some bloat from the tests:
There were many places where database changes the test made would be rolled back manually. This is an antipattern that relies too much on implementation details of the tested code.

The better way to do this is creating an empty database before each test run. This is actually already happening:
Since `NewRouteTest` will always create a new sqlite database and
it is run at the start of every test that is run, we are sure to
not have any effects of tests interfering eachother via the database.

**- Description for the changelog**

Refactor test code