### PR TITLE
Fix possible values for fulfillment state

### DIFF
--- a/api/order.go
+++ b/api/order.go
@@ -530,11 +530,13 @@ func (a *API) OrderUpdate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if orderParams.FulfillmentState != "" {
-		_, ok := map[string]bool{
-			"pending":  true,
-			"shipping": true,
-			"shipped":  true,
-		}[orderParams.FulfillmentState]
+		ok := false
+		for _, state := range models.FulfillmentStates {
+			if state == orderParams.FulfillmentState {
+				ok = true
+				break
+			}
+		}
 		if !ok {
 			tx.Rollback()
 			return badRequestError("Bad fulfillment state: " + orderParams.FulfillmentState)

--- a/models/order.go
+++ b/models/order.go
@@ -18,6 +18,9 @@ const PendingState = "pending"
 // PaidState is the paid state of an Order
 const PaidState = "paid"
 
+// ShippingState is the shipping state of an order
+const ShippingState = "shipping"
+
 // ShippedState is the shipped state of an Order
 const ShippedState = "shipped"
 
@@ -34,8 +37,8 @@ var PaymentStates = []string{
 // FulfillmentStates are the possible values for the FulfillmentState field
 var FulfillmentStates = []string{
 	PendingState,
+	ShippingState,
 	ShippedState,
-	FailedState,
 }
 
 // NumberType | StringType | BoolType are the different types supported in custom data for orders


### PR DESCRIPTION
**- Summary**

In 7d46f178208b3173521f5d08e757cdb001941fc9 a list of possible values for `fulfillment_state` filtering was introduced.
This commit brings this list on-par with what is accepted when updating orders. Both operations now use the same list.

**- Test plan**

The order update test have been improved with checks for the `fulfillment_state` field.

**- Description for the changelog**

Fix list of values for "fulfillment_state" when filtering orders

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://media.giphy.com/media/3oEduSbSGpGaRX2Vri/giphy.gif)