### PR TITLE
Fix rounding inaccuracies with quantity

### DIFF
--- a/calculator/calculator.go
+++ b/calculator/calculator.go
@@ -325,43 +325,6 @@ const (
 	fracMask = 1<<shift - 1
 )
 
-// Round returns the nearest integer, rounding half away from zero.
-//
-// Special cases are:
-//	Round(±0) = ±0
-//	Round(±Inf) = ±Inf
-//	Round(NaN) = NaN
-func Round(x float64) float64 {
-	// Round is a faster implementation of:
-	//
-	// func Round(x float64) float64 {
-	//   t := Trunc(x)
-	//   if Abs(x-t) >= 0.5 {
-	//     return t + Copysign(1, x)
-	//   }
-	//   return t
-	// }
-	bits := math.Float64bits(x)
-	e := uint(bits>>shift) & mask
-	if e < bias {
-		// Round abs(x) < 1 including denormals.
-		bits &= signMask // +-0
-		if e == bias-1 {
-			bits |= uvone // +-1
-		}
-	} else if e < bias+shift {
-		// Round any abs(x) >= 1 containing a fractional component [0,1).
-		//
-		// Numbers with larger exponents are returned unchanged since they
-		// must be either an integer, infinity, or NaN.
-		const half = 1 << (shift - 1)
-		e -= bias
-		bits += half >> e
-		bits &^= fracMask >> e
-	}
-	return math.Float64frombits(bits)
-}
-
 func rint(x float64) uint64 {
-	return uint64(Round(x))
+	return uint64(math.Round(x))
 }

--- a/calculator/calculator_test.go
+++ b/calculator/calculator_test.go
@@ -208,15 +208,11 @@ func TestCouponWithVATWhenPRiceIncludeTaxesWithQuantity(t *testing.T) {
 	params := PriceParameters{"USA", "USD", coupon, []Item{&TestItem{quantity: 2, price: 100, itemType: "test", vat: 9}}}
 	price := CalculatePrice(settings, nil, params, testLogger)
 
-	// todo: This result is wrong because a rounding inaccuracy is quantified
-	// Therefore the tax amount is not 9% of the net total
-	// Correct net total: 165
-	// Correct tax amount: 15
 	validatePrice(t, price, Price{
-		Subtotal: 184,
+		Subtotal: 183,
 		Discount: 20,
-		NetTotal: 166,
-		Taxes:    14,
+		NetTotal: 165,
+		Taxes:    15,
 		Total:    180,
 	})
 }


### PR DESCRIPTION
**- Summary**

There was a problem when using a quantity higher than 1 because
quantities were applied after rounding, therefore multiplying
rounding inaccuracies which is not acceptable.

Currently the amounts output in line items does not reflect the more
accurate values. There needs to be an API change to display single
and total amounts for items in orders.

**- Test plan**

Adjusted a test to take the now accurate amounts.

**- Description for the changelog**

Fix increase of rounding inaccuracies through item quantity