### PR TITLE
Add extra data to Stripe and PayPal payments

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -58,7 +58,7 @@ func (e *HTTPError) WithInternalError(err error) *HTTPError {
 
 // WithInternalMessage adds internal message information to the error
 func (e *HTTPError) WithInternalMessage(fmtString string, args ...interface{}) *HTTPError {
-	e.InternalMessage = fmt.Sprintf(fmtString, args)
+	e.InternalMessage = fmt.Sprintf(fmtString, args...)
 	return e
 }
 

--- a/api/payments.go
+++ b/api/payments.go
@@ -111,7 +111,8 @@ func (a *API) PaymentCreate(w http.ResponseWriter, r *http.Request) error {
 	loader := tx.
 		Preload("LineItems").
 		Preload("Downloads").
-		Preload("BillingAddress")
+		Preload("BillingAddress").
+		Preload("ShippingAddress")
 	if result := loader.First(order, "id = ?", orderID); result.Error != nil {
 		tx.Rollback()
 		if result.RecordNotFound() {
@@ -162,7 +163,7 @@ func (a *API) PaymentCreate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	tr := models.NewTransaction(order)
-	processorID, err := charge(params.Amount, params.Currency)
+	processorID, err := charge(params.Amount, params.Currency, order, invoiceNumber)
 	tr.ProcessorID = processorID
 	tr.InvoiceNumber = invoiceNumber
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5c323ab6120aa0196280c039ea80bc8f21a76f34c6880c47935603b6eff9cc8d
-updated: 2018-10-18T17:14:54.331248849+02:00
+hash: f58e7d7de016287b05b21a07ea82c3f4c50ea7128fe3ff714247a4d9299f7f72
+updated: 2018-11-04T03:17:57.948793496+01:00
 imports:
 - name: cloud.google.com/go
   version: 98f5696b1026056a47f114c4451dbc4703d67191
@@ -136,9 +136,10 @@ imports:
 - name: github.com/streadway/amqp
   version: 2cbfe40c9341ad63ba23e53013b3ddc7989d801c
 - name: github.com/stripe/stripe-go
-  version: 250fb5fdb3e4001e3388f6410f648ea178b3262e
+  version: e2f967acf5f1f5b75ce29b3e633c082074359029
   subpackages:
   - account
+  - applepaydomain
   - balance
   - bankaccount
   - bitcoinreceiver
@@ -153,28 +154,47 @@ imports:
   - dispute
   - ephemeralkey
   - event
+  - exchangerate
   - fee
   - feerefund
-  - fileupload
+  - file
+  - filelink
+  - form
   - invoice
   - invoiceitem
+  - issuerfraudrecord
+  - issuing/authorization
+  - issuing/card
+  - issuing/cardholder
+  - issuing/dispute
+  - issuing/transaction
   - loginlink
   - order
-  - orderitem
   - orderreturn
+  - paymentintent
   - paymentsource
   - payout
   - plan
   - product
   - recipient
   - refund
+  - reporting/reportrun
+  - reporting/reporttype
   - reversal
+  - sigma/scheduledqueryrun
   - sku
   - source
+  - sourcetransaction
   - sub
   - subitem
+  - terminal/connectiontoken
+  - terminal/location
+  - terminal/reader
   - token
+  - topup
   - transfer
+  - usagerecord
+  - webhookendpoint
 - name: golang.org/x/net
   version: ab5485076ff3407ad2d02db054635913f017b0ed
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f58e7d7de016287b05b21a07ea82c3f4c50ea7128fe3ff714247a4d9299f7f72
-updated: 2018-11-04T03:17:57.948793496+01:00
+hash: 553e340d93bbe27e6d1fd002ec1044fb5b15fd8c749a6638062dee7a4f0eee0f
+updated: 2018-11-04T03:21:50.787173992+01:00
 imports:
 - name: cloud.google.com/go
   version: 98f5696b1026056a47f114c4451dbc4703d67191
@@ -87,6 +87,8 @@ imports:
   - tls
 - name: github.com/netlify/PayPal-Go-SDK
   version: 732c3d08bf8a673d3d0ae345bfe771a573006890
+- name: github.com/pariz/gountries
+  version: adb00f6513a307f9f7a4ee57eca79a703b8a7272
 - name: github.com/pborman/uuid
   version: a97ce2ca70fa5a848076093f05e639a89ca34d06
 - name: github.com/pelletier/go-toml

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,7 +18,7 @@ import:
 - package: github.com/netlify/mailme
   version: c4a76ce443c1122ead2518b28cc7ffaf1091cc9a
 - package: github.com/stripe/stripe-go
-  version: v24.0.0
+  version: ^v52.0.0
   subpackages:
   - client
 - package: gopkg.in/gomail.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,6 +44,8 @@ import:
   version: v1.3.0
 - package: github.com/imdario/mergo
   version: 0.2.2
+- package: github.com/pariz/gountries
+  version: 0.1.3
 testImport:
 - package: github.com/stretchr/testify
   version: v1.1.3

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -3,6 +3,8 @@ package payments
 import (
 	"context"
 	"net/http"
+
+	"github.com/netlify/gocommerce/models"
 )
 
 const (
@@ -22,7 +24,7 @@ type Provider interface {
 }
 
 // Charger wraps the Charge method which creates new payments with the provider.
-type Charger func(amount uint64, currency string) (string, error)
+type Charger func(amount uint64, currency string, order *models.Order, invoiceNumber int64) (string, error)
 
 // Refunder wraps the Refund method which refunds payments with the provider.
 type Refunder func(transactionID string, amount uint64, currency string) (string, error)

--- a/payments/stripe/stripe.go
+++ b/payments/stripe/stripe.go
@@ -2,10 +2,12 @@ package stripe
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"encoding/json"
 
+	"github.com/netlify/gocommerce/models"
 	"github.com/netlify/gocommerce/payments"
 	"github.com/pkg/errors"
 	stripe "github.com/stripe/stripe-go"
@@ -56,18 +58,39 @@ func (s *stripePaymentProvider) NewCharger(ctx context.Context, r *http.Request)
 		return nil, errors.New("Stripe requires a stripe_token for creating a payment")
 	}
 
-	return func(amount uint64, currency string) (string, error) {
-		return s.charge(bp.StripeToken, amount, currency)
+	return func(amount uint64, currency string, order *models.Order, invoiceNumber int64) (string, error) {
+		return s.charge(bp.StripeToken, amount, currency, order, invoiceNumber)
 	}, nil
 }
 
-func (s *stripePaymentProvider) charge(token string, amount uint64, currency string) (string, error) {
+func prepareShippingAddress(addr models.Address) *stripe.ShippingDetailsParams {
+	return &stripe.ShippingDetailsParams{
+		Address: &stripe.AddressParams{
+			Line1:      &addr.Address1,
+			Line2:      &addr.Address2,
+			City:       &addr.City,
+			State:      &addr.State,
+			PostalCode: &addr.Zip,
+			Country:    &addr.Country,
+		},
+	}
+}
+
+func (s *stripePaymentProvider) charge(token string, amount uint64, currency string, order *models.Order, invoiceNumber int64) (string, error) {
 	stripeAmount := int64(amount)
 	stripeDescription := fmt.Sprintf("Invoice No. %d", invoiceNumber)
 	ch, err := s.client.Charges.New(&stripe.ChargeParams{
 		Amount:      &stripeAmount,
 		Source:      &stripe.SourceParams{Token: &token},
 		Currency:    &currency,
+		Description: &stripeDescription,
+		Shipping:    prepareShippingAddress(order.ShippingAddress),
+		Params: stripe.Params{
+			Metadata: map[string]string{
+				"order_id":       order.ID,
+				"invoice_number": fmt.Sprintf("%d", invoiceNumber),
+			},
+		},
 	})
 
 	if err != nil {

--- a/payments/stripe/stripe.go
+++ b/payments/stripe/stripe.go
@@ -62,10 +62,12 @@ func (s *stripePaymentProvider) NewCharger(ctx context.Context, r *http.Request)
 }
 
 func (s *stripePaymentProvider) charge(token string, amount uint64, currency string) (string, error) {
+	stripeAmount := int64(amount)
+	stripeDescription := fmt.Sprintf("Invoice No. %d", invoiceNumber)
 	ch, err := s.client.Charges.New(&stripe.ChargeParams{
-		Amount:   amount,
-		Source:   &stripe.SourceParams{Token: token},
-		Currency: stripe.Currency(currency),
+		Amount:      &stripeAmount,
+		Source:      &stripe.SourceParams{Token: &token},
+		Currency:    &currency,
 	})
 
 	if err != nil {
@@ -80,9 +82,10 @@ func (s *stripePaymentProvider) NewRefunder(ctx context.Context, r *http.Request
 }
 
 func (s *stripePaymentProvider) refund(transactionID string, amount uint64, currency string) (string, error) {
+	stripeAmount := int64(amount)
 	ref, err := s.client.Refunds.New(&stripe.RefundParams{
-		Charge: transactionID,
-		Amount: amount,
+		Charge: &transactionID,
+		Amount: &stripeAmount,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fixes #125

**- Summary**

This will add more info to the payments created with Stripe and PayPal.

For Stripe:
- Shipping Address
- Invoice Number
- Metadata (Order id)

For PayPal:
- Items with Quantity and Original Price
- Shipping Address

**- Test plan**

Paypal and Stripe payment tests have been extended with checks for the additional attributes.

**- Description for the changelog**

Extend Stripe and PayPal payments with order metadata.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://media.giphy.com/media/ujxoCyTq9HnsA/giphy.gif)