### PR TITLE
Fix error when querying by creation range

### DIFF
--- a/api/download.go
+++ b/api/download.go
@@ -110,11 +110,11 @@ func (a *API) DownloadList(w http.ResponseWriter, r *http.Request) error {
 	orderTable := a.db.NewScope(models.Order{}).QuotedTableName()
 	downloadsTable := a.db.NewScope(models.Download{}).QuotedTableName()
 
-	query := a.db.Joins("join " + orderTable + " as orders ON " + downloadsTable + ".order_id = orders.id and orders.payment_state = 'paid'")
+	query := a.db.Joins("join " + orderTable + " as orders ON " + downloadsTable + ".order_id = " + orderTable + ".id and " + orderTable + ".payment_state = 'paid'")
 	if order != nil {
-		query = query.Where("orders.id = ?", order.ID)
+		query = query.Where(orderTable+".id = ?", order.ID)
 	} else {
-		query = query.Where("orders.user_id = ?", claims.Subject)
+		query = query.Where(orderTable+".user_id = ?", claims.Subject)
 	}
 
 	offset, limit, err := paginate(w, r, query.Model(&models.Download{}))

--- a/api/order_test.go
+++ b/api/order_test.go
@@ -333,6 +333,16 @@ func TestOrdersList(t *testing.T) {
 			extractPayload(t, http.StatusOK, recorder, &orders)
 			assert.Len(t, orders, 1)
 		})
+		t.Run("RangeWithParams", func(t *testing.T) {
+			test := NewRouteTest(t)
+			token := test.Data.testUserToken
+			url := fmt.Sprintf("/orders?per_page=50&page=1&from=%d&billing_countries=dcland", test.Data.firstOrder.CreatedAt.Unix())
+			recorder := test.TestEndpoint(http.MethodGet, url, nil, token)
+
+			orders := []models.Order{}
+			extractPayload(t, http.StatusOK, recorder, &orders)
+			assert.Len(t, orders, 2)
+		})
 	})
 	t.Run("Pagination", func(t *testing.T) {
 		test := NewRouteTest(t)

--- a/api/params.go
+++ b/api/params.go
@@ -39,11 +39,11 @@ func parsePaymentQueryParams(query *gorm.DB, params url.Values) (*gorm.DB, error
 	})
 
 	if values, exists := params["min_amount"]; exists {
-		query = query.Where("amount >= ?", values[0])
+		query = query.Where(transactionTable+".amount >= ?", values[0])
 	}
 
 	if values, exists := params["max_amount"]; exists {
-		query = query.Where("amount <= ?", values[0])
+		query = query.Where(transactionTable+".amount <= ?", values[0])
 	}
 
 	query, err := parseLimitQueryParam(query, params)
@@ -124,11 +124,13 @@ func addNegativeAddressFilter(query *gorm.DB, params url.Values, queryField stri
 }
 
 func parseOrderParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {
+	orderTable := query.NewScope(models.Order{}).QuotedTableName()
+
 	if tax := params.Get("tax"); tax != "" {
 		if tax == "yes" || tax == "true" {
-			query = query.Where("taxes > 0")
+			query = query.Where(orderTable + ".taxes > 0")
 		} else {
-			query = query.Where("taxes = 0")
+			query = query.Where(orderTable + ".taxes = 0")
 		}
 	}
 
@@ -159,8 +161,6 @@ func parseOrderParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {
 	} else {
 		query = query.Order("created_at desc")
 	}
-
-	orderTable := query.NewScope(models.Order{}).QuotedTableName()
 
 	if items := params.Get("items"); items != "" {
 		lineItemTable := query.NewScope(models.LineItem{}).QuotedTableName()

--- a/api/params.go
+++ b/api/params.go
@@ -27,7 +27,8 @@ var sortFields = map[string]string{
 }
 
 func parsePaymentQueryParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {
-	query = addFilters(query, query.NewScope(models.Transaction{}).QuotedTableName(), params, []string{
+	transactionTable := query.NewScope(models.Transaction{}).QuotedTableName()
+	query = addFilters(query, transactionTable, params, []string{
 		"processor_id",
 		"user_id",
 		"order_id",
@@ -49,7 +50,7 @@ func parsePaymentQueryParams(query *gorm.DB, params url.Values) (*gorm.DB, error
 	if err != nil {
 		return nil, err
 	}
-	return parseTimeQueryParams(query, params)
+	return parseTimeQueryParams(query, transactionTable, params)
 }
 
 func parseUserBulkDeleteParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {
@@ -78,7 +79,7 @@ func parseUserQueryParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	return parseTimeQueryParams(query, params)
+	return parseTimeQueryParams(query, userTable, params)
 }
 
 func sortField(value string) string {
@@ -193,7 +194,7 @@ func parseOrderParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {
 		"coupon_code",
 	})
 
-	return parseTimeQueryParams(query, params)
+	return parseTimeQueryParams(query, orderTable, params)
 }
 
 func parseLimitQueryParam(query *gorm.DB, params url.Values) (*gorm.DB, error) {
@@ -229,16 +230,16 @@ func getTimeQueryParams(params url.Values) (from *time.Time, to *time.Time, err 
 	return
 }
 
-func parseTimeQueryParams(query *gorm.DB, params url.Values) (*gorm.DB, error) {
+func parseTimeQueryParams(query *gorm.DB, tableName string, params url.Values) (*gorm.DB, error) {
 	from, to, err := getTimeQueryParams(params)
 	if err != nil {
 		return nil, err
 	}
 	if from != nil {
-		query = query.Where("created_at >= ?", from)
+		query = query.Where(tableName+".created_at >= ?", from)
 	}
 	if to != nil {
-		query = query.Where("created_at <= ?", to)
+		query = query.Where(tableName+".created_at <= ?", to)
 	}
 	return query, nil
 }

--- a/api/reports.go
+++ b/api/reports.go
@@ -32,7 +32,7 @@ func (a *API) SalesReport(w http.ResponseWriter, r *http.Request) error {
 		Where("payment_state = 'paid' AND instance_id = ?", instanceID).
 		Group("currency")
 
-	query, err := parseTimeQueryParams(query, r.URL.Query())
+	query, err := parseTimeQueryParams(query, query.NewScope(models.Order{}).QuotedTableName(), r.URL.Query())
 	if err != nil {
 		return badRequestError(err.Error())
 	}

--- a/api/reports.go
+++ b/api/reports.go
@@ -67,16 +67,16 @@ func (a *API) ProductsReport(w http.ResponseWriter, r *http.Request) error {
 		Group("sku, path, currency").
 		Order("total desc")
 
-	query = query.Where("orders.instance_id = ?", instanceID)
+	query = query.Where(ordersTable+".instance_id = ?", instanceID)
 	from, to, err := getTimeQueryParams(r.URL.Query())
 	if err != nil {
 		return badRequestError(err.Error())
 	}
 	if from != nil {
-		query = query.Where("orders.created_at >= ?", from)
+		query = query.Where(ordersTable+".created_at >= ?", from)
 	}
 	if to != nil {
-		query.Where("orders.created_at <= ?", to)
+		query.Where(ordersTable+".created_at <= ?", to)
 	}
 
 	rows, err := query.Rows()


### PR DESCRIPTION
Fixes #158

**- Summary**

There was a point where fields in  query filters were not prefixed with the correct table name in a join. This has been fixed.
Also contains another commit ensuring the table name is always taken from the ORM and is not a string literal.

**- Test plan**

A regression test for the fixed issue has been added.

**- Description for the changelog**

Fix issue with sql error when querying orders with creation range

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://media.giphy.com/media/vNMZCm2biS7Cw/giphy.gif)