### PR TITLE
Fix stripe charge params due to api change

### DIFF
--- a/payments/stripe/stripe.go
+++ b/payments/stripe/stripe.go
@@ -73,6 +73,7 @@ func prepareShippingAddress(addr models.Address) *stripe.ShippingDetailsParams {
 			PostalCode: &addr.Zip,
 			Country:    &addr.Country,
 		},
+		Name: &addr.Name,
 	}
 }
 


### PR DESCRIPTION
**- Summary**

This fixes a recently discovered regression in the Stripe API where the `name` attribute is now required when supplying shipping info.

**- Test plan**

To test this, stripe would need to release a mock api server we could start with our tests. There is no other way to test for external api changes, since the Stripe SDK does not seem to catch this but rather only serializes the params to JSON and does no validation.

**- Description for the changelog**

Fix Stripe API regression by passing name parameter for shipping details

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://media.giphy.com/media/n7VasukVCpiGk/giphy.gif)