### PR TITLE
Optimize indices for large tables

### DIFF
--- a/models/download.go
+++ b/models/download.go
@@ -22,7 +22,7 @@ type Download struct {
 
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`
-	DeletedAt *time.Time `json:"-" sql:"index:idx_downloads_deleted_at"`
+	DeletedAt *time.Time `json:"-" sql:"index"`
 }
 
 // TableName returns the database table name for the Download model.

--- a/models/order.go
+++ b/models/order.go
@@ -50,7 +50,7 @@ const (
 
 // Order model
 type Order struct {
-	InstanceID    string `json:"-"`
+	InstanceID    string `json:"-" sql:"index"`
 	ID            string `json:"id"`
 	InvoiceNumber int64  `json:"invoice_number,omitempty"`
 
@@ -100,9 +100,9 @@ type Order struct {
 	Coupon    *Coupon `json:"coupon,omitempty" sql:"-"`
 	RawCoupon string  `json:"-" sql:"type:text"`
 
-	CreatedAt time.Time  `json:"created_at"`
+	CreatedAt time.Time  `json:"created_at" sql:"index"`
 	UpdatedAt time.Time  `json:"updated_at"`
-	DeletedAt *time.Time `json:"-" sql:"index:idx_orders_deleted_at"`
+	DeletedAt *time.Time `json:"-" sql:"index"`
 }
 
 // TableName returns the database table name for the Order model.


### PR DESCRIPTION
Fixes #169

**- Summary**

Adding an index on `instance_id` and `created_at` will allow the dataset to be ordered and filtered a lot faster, especially when there are a lot of orders.
Also, since the custom names for indices are removed, indices will now be properly prefixed with the table namespace.

**Warning:**
Automigrations on large databases might take a little longer since the index will need to be populated.

**- Test plan**

There are no performance tests at all.
Apart from that, the existing tests cover most applications of the impacted fields.

**- Description for the changelog**

Optimize sql queries by adding indices

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://media.giphy.com/media/9KorRVD13syoU/giphy.gif)