### PR TITLE
Support Strong Customer Authentication using Stripe with PaymentIntent

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -116,12 +116,11 @@ func NewAPIWithVersion(ctx context.Context, globalConfig *conf.GlobalConfigurati
 		})
 
 		r.Route("/payments", func(r *router) {
-			r.Use(adminRequired)
-
-			r.Get("/", api.PaymentList)
+			r.With(adminRequired).Get("/", api.PaymentList)
 			r.Route("/{payment_id}", func(r *router) {
-				r.Get("/", api.PaymentView)
-				r.With(addGetBody).Post("/refund", api.PaymentRefund)
+				r.With(adminRequired).Get("/", api.PaymentView)
+				r.With(adminRequired).With(addGetBody).Post("/refund", api.PaymentRefund)
+				r.Post("/confirm", api.PaymentConfirm)
 			})
 		})
 

--- a/api/payments.go
+++ b/api/payments.go
@@ -302,7 +302,7 @@ func (a *API) PaymentConfirm(w http.ResponseWriter, r *http.Request) error {
 
 	go sendOrderConfirmation(ctx, log, trans)
 
-	return sendJSON(w, 200, trans)
+	return sendJSON(w, http.StatusOK, trans)
 }
 
 // PaymentList will list all the payments that meet the criteria. It is only available to admins.

--- a/api/payments.go
+++ b/api/payments.go
@@ -205,16 +205,16 @@ func (a *API) PaymentCreate(w http.ResponseWriter, r *http.Request) error {
 	tr.InvoiceNumber = invoiceNumber
 	order.PaymentProcessor = provider.Name()
 
-	if pendingErr, ok := err.(*payments.PaymentPendingError); ok {
-		tr.Status = models.PendingState
-		tr.ProviderMetadata = pendingErr.Metadata()
-		tx.Create(tr)
-		tx.Save(order)
-		tx.Commit()
-		return sendJSON(w, 200, tr)
-	}
-
 	if err != nil {
+		if pendingErr, ok := err.(*payments.PaymentPendingError); ok {
+			tr.Status = models.PendingState
+			tr.ProviderMetadata = pendingErr.Metadata()
+			tx.Create(tr)
+			tx.Save(order)
+			tx.Commit()
+			return sendJSON(w, 200, tr)
+		}
+
 		tr.FailureCode = strconv.FormatInt(http.StatusInternalServerError, 10)
 		tr.FailureDescription = err.Error()
 		tr.Status = models.FailedState

--- a/api/payments.go
+++ b/api/payments.go
@@ -224,7 +224,9 @@ func (a *API) PaymentCreate(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	paymentComplete(r, tx, tr, order)
-	tx.Commit()
+	if err := tx.Commit().Error; err != nil {
+		return internalServerError("Saving payment failed").WithInternalError(err)
+	}
 
 	go sendOrderConfirmation(ctx, log, tr)
 

--- a/api/payments.go
+++ b/api/payments.go
@@ -253,6 +253,10 @@ func (a *API) PaymentConfirm(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	if trans.Status == models.PaidState {
+		return sendJSON(w, http.StatusOK, trans)
+	}
+
 	order := &models.Order{}
 	if rsp := a.db.Find(order, "id = ?", trans.OrderID); rsp.Error != nil {
 		if rsp.RecordNotFound() {

--- a/api/payments.go
+++ b/api/payments.go
@@ -86,7 +86,11 @@ func paymentComplete(r *http.Request, tx *gorm.DB, tr *models.Transaction, order
 	config := gcontext.GetConfig(ctx)
 
 	tr.Status = models.PaidState
-	tx.Create(tr)
+	if tx.NewRecord(tr) {
+		tx.Create(tr)
+	} else {
+		tx.Save(tr)
+	}
 	order.PaymentState = models.PaidState
 	tx.Save(order)
 

--- a/api/payments_test.go
+++ b/api/payments_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -659,14 +660,17 @@ type refundCall struct {
 func (mp *memProvider) Name() string {
 	return mp.name
 }
-func (mp *memProvider) NewCharger(ctx context.Context, r *http.Request) (payments.Charger, error) {
+func (mp *memProvider) NewCharger(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Charger, error) {
 	return mp.charge, nil
 }
-func (mp *memProvider) NewRefunder(ctx context.Context, r *http.Request) (payments.Refunder, error) {
+func (mp *memProvider) NewRefunder(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Refunder, error) {
 	return mp.refund, nil
 }
-func (mp *memProvider) NewPreauthorizer(ctx context.Context, r *http.Request) (payments.Preauthorizer, error) {
+func (mp *memProvider) NewPreauthorizer(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Preauthorizer, error) {
 	return mp.preauthorize, nil
+}
+func (mp *memProvider) NewConfirmer(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Confirmer, error) {
+	return mp.confirm, nil
 }
 
 func (mp *memProvider) charge(amount uint64, currency string, order *models.Order, invoiceNumber int64) (string, error) {
@@ -688,6 +692,10 @@ func (mp *memProvider) refund(transactionID string, amount uint64, currency stri
 
 func (mp *memProvider) preauthorize(amount uint64, currency string, description string) (*payments.PreauthorizationResult, error) {
 	return nil, nil
+}
+
+func (mp *memProvider) confirm(paymentID string) error {
+	return nil
 }
 
 type stripeCallFunc func(method, path, key string, params stripe.ParamsContainer, v interface{})

--- a/api/payments_test.go
+++ b/api/payments_test.go
@@ -429,6 +429,7 @@ func TestPaymentCreate(t *testing.T) {
 		t.Run("PaymentIntent", func(t *testing.T) {
 			stripeCardSimple := "payment-method-simple"
 			stripeCardSCA := "payment-method-sca"
+			stripeClientSecret := "payment-intent-secret"
 
 			tests := map[string]string{
 				"AutomaticConfirm": stripeCardSimple,
@@ -462,6 +463,7 @@ func TestPaymentCreate(t *testing.T) {
 									intent.Status = stripe.PaymentIntentStatusSucceeded
 								case stripeCardSCA:
 									intent.Status = stripe.PaymentIntentStatusRequiresAction
+									intent.ClientSecret = stripeClientSecret
 								default:
 									t.Errorf("unknown payment method: %s", pm)
 								}
@@ -505,6 +507,9 @@ func TestPaymentCreate(t *testing.T) {
 					}
 					assert.Equal(t, expectedStatus, trans.Status)
 					assert.Equal(t, stripePaymentIntentID, trans.ProcessorID)
+					if expectedStatus == models.PendingState {
+						assert.Equal(t, trans.ProviderMetadata["payment_intent_secret"], stripeClientSecret)
+					}
 					assert.Equal(t, 1, callCount)
 
 					order := &models.Order{}

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -67,6 +67,8 @@ type Configuration struct {
 			Enabled   bool   `json:"enabled"`
 			PublicKey string `json:"public_key" split_words:"true"`
 			SecretKey string `json:"secret_key" split_words:"true"`
+
+			UsePaymentIntents bool `json:"use_payment_intents" split_words:"true"`
 		} `json:"stripe"`
 		PayPal struct {
 			Enabled  bool   `json:"enabled"`

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -37,6 +37,8 @@ type Transaction struct {
 
 	CreatedAt time.Time  `json:"created_at"`
 	DeletedAt *time.Time `json:"-"`
+
+	ProviderMetadata map[string]interface{} `json:"provider_metadata,omitempty" sql:"-"`
 }
 
 // TableName returns the database table name for the Transaction model.

--- a/payments/payments.go
+++ b/payments/payments.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/netlify/gocommerce/models"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -18,9 +19,10 @@ const (
 // preauthorize payments.
 type Provider interface {
 	Name() string
-	NewCharger(ctx context.Context, r *http.Request) (Charger, error)
-	NewRefunder(ctx context.Context, r *http.Request) (Refunder, error)
-	NewPreauthorizer(ctx context.Context, r *http.Request) (Preauthorizer, error)
+	NewCharger(ctx context.Context, r *http.Request, log logrus.FieldLogger) (Charger, error)
+	NewRefunder(ctx context.Context, r *http.Request, log logrus.FieldLogger) (Refunder, error)
+	NewPreauthorizer(ctx context.Context, r *http.Request, log logrus.FieldLogger) (Preauthorizer, error)
+	NewConfirmer(ctx context.Context, r *http.Request, log logrus.FieldLogger) (Confirmer, error)
 }
 
 // Charger wraps the Charge method which creates new payments with the provider.
@@ -36,4 +38,42 @@ type Preauthorizer func(amount uint64, currency string, description string) (*Pr
 // PreauthorizationResult contains the data returned from a Preauthorization.
 type PreauthorizationResult struct {
 	ID string `json:"id"`
+}
+
+// Confirmer wraps a confirm method used for checking two-step payments in a synchronous flow
+type Confirmer func(paymentID string) error
+
+// PaymentPendingError is returned when the payment provider requests additional action
+// e.g. 2-step authorization through 3D secure
+type PaymentPendingError struct {
+	metadata map[string]interface{}
+}
+
+// NewPaymentPendingError creates an error for a pending action on a payment
+func NewPaymentPendingError(metadata map[string]interface{}) error {
+	return &PaymentPendingError{metadata}
+}
+
+func (p *PaymentPendingError) Error() string {
+	return "The payment provider requested additional actions on the transaction."
+}
+
+// Metadata returns fields that should be passed to the client
+// for use in additional actions
+func (p *PaymentPendingError) Metadata() map[string]interface{} {
+	return p.metadata
+}
+
+// PaymentConfirmFailError is returned when the confirmation request got a negative response
+type PaymentConfirmFailError struct {
+	message string
+}
+
+// NewPaymentConfirmFailError creates an error to use when a payment confirmation fails
+func NewPaymentConfirmFailError(msg string) error {
+	return &PaymentConfirmFailError{message: msg}
+}
+
+func (p *PaymentConfirmFailError) Error() string {
+	return p.message
 }

--- a/payments/paypal/paypal.go
+++ b/payments/paypal/paypal.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/netlify/gocommerce/models"
 	"github.com/pariz/gountries"
+	"github.com/sirupsen/logrus"
 
 	paypalsdk "github.com/netlify/PayPal-Go-SDK"
 	"github.com/netlify/gocommerce/conf"
@@ -76,7 +77,7 @@ func (p *paypalPaymentProvider) Name() string {
 	return payments.PayPalProvider
 }
 
-func (p *paypalPaymentProvider) NewCharger(ctx context.Context, r *http.Request) (payments.Charger, error) {
+func (p *paypalPaymentProvider) NewCharger(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Charger, error) {
 	var bp paypalBodyParams
 	bod, err := r.GetBody()
 	if err != nil {
@@ -193,7 +194,7 @@ func (p *paypalPaymentProvider) charge(paymentID string, userID string, amount u
 	return executeResult.ID, nil
 }
 
-func (p *paypalPaymentProvider) NewRefunder(ctx context.Context, r *http.Request) (payments.Refunder, error) {
+func (p *paypalPaymentProvider) NewRefunder(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Refunder, error) {
 	return p.refund, nil
 }
 
@@ -209,7 +210,7 @@ func (p *paypalPaymentProvider) refund(transactionID string, amount uint64, curr
 	return ref.ID, nil
 }
 
-func (p *paypalPaymentProvider) NewPreauthorizer(ctx context.Context, r *http.Request) (payments.Preauthorizer, error) {
+func (p *paypalPaymentProvider) NewPreauthorizer(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Preauthorizer, error) {
 	config := gcontext.GetConfig(ctx)
 	return func(amount uint64, currency string, description string) (*payments.PreauthorizationResult, error) {
 		return p.preauthorize(config, amount, currency, description)
@@ -277,4 +278,8 @@ func (p *paypalPaymentProvider) getExperience() (*paypalsdk.WebProfile, error) {
 
 func formatAmount(amount uint64) string {
 	return strconv.FormatFloat(float64(amount)/100, 'f', 2, 64)
+}
+
+func (p *paypalPaymentProvider) NewConfirmer(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Confirmer, error) {
+	return nil, errors.New("Paypal does not provide manual 2-step confirmation")
 }

--- a/payments/stripe/stripe.go
+++ b/payments/stripe/stripe.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/client"
-	"github.com/stripe/stripe-go/paymentintent"
 )
 
 type stripePaymentProvider struct {
@@ -137,7 +136,7 @@ func (s *stripePaymentProvider) chargePaymentIntent(paymentMethodID string, amou
 		)),
 		Confirm: stripe.Bool(true),
 	}
-	intent, err := paymentintent.New(params)
+	intent, err := s.client.PaymentIntents.New(params)
 	if err != nil {
 		return "", err
 	}
@@ -185,7 +184,7 @@ func (s *stripePaymentProvider) NewConfirmer(ctx context.Context, r *http.Reques
 }
 
 func (s *stripePaymentProvider) confirm(paymentID string) error {
-	_, err := paymentintent.Confirm(paymentID, nil)
+	_, err := s.client.PaymentIntents.Confirm(paymentID, nil)
 
 	if stripeErr, ok := err.(*stripe.Error); ok {
 		return payments.NewPaymentConfirmFailError(stripeErr.Msg)

--- a/payments/stripe/stripe.go
+++ b/payments/stripe/stripe.go
@@ -10,21 +10,27 @@ import (
 	"github.com/netlify/gocommerce/models"
 	"github.com/netlify/gocommerce/payments"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	stripe "github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/client"
+	"github.com/stripe/stripe-go/paymentintent"
 )
 
 type stripePaymentProvider struct {
 	client *client.API
+
+	usePaymentIntents bool
 }
 
 type stripeBodyParams struct {
-	StripeToken string `json:"stripe_token"`
+	StripeToken           string `json:"stripe_token"`
+	StripePaymentMethodID string `json:"stripe_payment_method_id"`
 }
 
 // Config contains the Stripe-specific configuration for payment providers.
 type Config struct {
-	SecretKey string `mapstructure:"secret_key" json:"secret_key"`
+	SecretKey         string `mapstructure:"secret_key" json:"secret_key"`
+	UsePaymentIntents bool   `mapstructure:"use_payment_intents" json:"use_payment_intents"`
 }
 
 // NewPaymentProvider creates a new Stripe payment provider using the provided configuration.
@@ -35,6 +41,8 @@ func NewPaymentProvider(config Config) (payments.Provider, error) {
 
 	s := stripePaymentProvider{
 		client: &client.API{},
+
+		usePaymentIntents: config.UsePaymentIntents,
 	}
 	s.client.Init(config.SecretKey, nil)
 	return &s, nil
@@ -44,7 +52,7 @@ func (s *stripePaymentProvider) Name() string {
 	return payments.StripeProvider
 }
 
-func (s *stripePaymentProvider) NewCharger(ctx context.Context, r *http.Request) (payments.Charger, error) {
+func (s *stripePaymentProvider) NewCharger(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Charger, error) {
 	var bp stripeBodyParams
 	bod, err := r.GetBody()
 	if err != nil {
@@ -54,12 +62,22 @@ func (s *stripePaymentProvider) NewCharger(ctx context.Context, r *http.Request)
 	if err != nil {
 		return nil, err
 	}
-	if bp.StripeToken == "" {
-		return nil, errors.New("Stripe requires a stripe_token for creating a payment")
+
+	if !s.usePaymentIntents {
+		log.Warning(`Deprecation Warning: Payment Intents are not enabled. Stripe requires those after Sep 14th 2019. Enable by setting "payment.stripe.use_payment_intents" to true`)
+		if bp.StripeToken == "" {
+			return nil, errors.New("Stripe requires a stripe_token for creating a payment")
+		}
+		return func(amount uint64, currency string, order *models.Order, invoiceNumber int64) (string, error) {
+			return s.chargeDeprecated(bp.StripeToken, amount, currency, order, invoiceNumber)
+		}, nil
 	}
 
+	if bp.StripePaymentMethodID == "" {
+		return nil, errors.New("Stripe requires a stripe_payment_method_id for creating a payment intent")
+	}
 	return func(amount uint64, currency string, order *models.Order, invoiceNumber int64) (string, error) {
-		return s.charge(bp.StripeToken, amount, currency, order, invoiceNumber)
+		return s.chargePaymentIntent(bp.StripePaymentMethodID, amount, currency, order, invoiceNumber)
 	}, nil
 }
 
@@ -77,7 +95,7 @@ func prepareShippingAddress(addr models.Address) *stripe.ShippingDetailsParams {
 	}
 }
 
-func (s *stripePaymentProvider) charge(token string, amount uint64, currency string, order *models.Order, invoiceNumber int64) (string, error) {
+func (s *stripePaymentProvider) chargeDeprecated(token string, amount uint64, currency string, order *models.Order, invoiceNumber int64) (string, error) {
 	stripeAmount := int64(amount)
 	stripeDescription := fmt.Sprintf("Invoice No. %d", invoiceNumber)
 	ch, err := s.client.Charges.New(&stripe.ChargeParams{
@@ -101,7 +119,43 @@ func (s *stripePaymentProvider) charge(token string, amount uint64, currency str
 	return ch.ID, nil
 }
 
-func (s *stripePaymentProvider) NewRefunder(ctx context.Context, r *http.Request) (payments.Refunder, error) {
+func (s *stripePaymentProvider) chargePaymentIntent(paymentMethodID string, amount uint64, currency string, order *models.Order, invoiceNumber int64) (string, error) {
+	params := &stripe.PaymentIntentParams{
+		PaymentMethod: stripe.String(paymentMethodID),
+		Amount:        stripe.Int64(int64(amount)),
+		Currency:      stripe.String(currency),
+		Description:   stripe.String(fmt.Sprintf("Invoice No. %d", invoiceNumber)),
+		Shipping:      prepareShippingAddress(order.ShippingAddress),
+		Params: stripe.Params{
+			Metadata: map[string]string{
+				"order_id":       order.ID,
+				"invoice_number": fmt.Sprintf("%d", invoiceNumber),
+			},
+		},
+		ConfirmationMethod: stripe.String(string(
+			stripe.PaymentIntentConfirmationMethodManual,
+		)),
+		Confirm: stripe.Bool(true),
+	}
+	intent, err := paymentintent.New(params)
+	if err != nil {
+		return "", err
+	}
+
+	if intent.Status == stripe.PaymentIntentStatusRequiresAction {
+		return intent.ID, payments.NewPaymentPendingError(map[string]interface{}{
+			"payment_intent_secret": intent.ClientSecret,
+		})
+	}
+
+	if intent.Status == stripe.PaymentIntentStatusSucceeded {
+		return intent.ID, nil
+	}
+
+	return "", fmt.Errorf("Invalid PaymentIntent status: %s", intent.Status)
+}
+
+func (s *stripePaymentProvider) NewRefunder(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Refunder, error) {
 	return s.refund, nil
 }
 
@@ -118,6 +172,24 @@ func (s *stripePaymentProvider) refund(transactionID string, amount uint64, curr
 	return ref.ID, err
 }
 
-func (s *stripePaymentProvider) NewPreauthorizer(ctx context.Context, r *http.Request) (payments.Preauthorizer, error) {
+func (s *stripePaymentProvider) NewPreauthorizer(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Preauthorizer, error) {
 	return nil, errors.New("Stripe does not require preauthorization")
+}
+
+func (s *stripePaymentProvider) NewConfirmer(ctx context.Context, r *http.Request, log logrus.FieldLogger) (payments.Confirmer, error) {
+	if !s.usePaymentIntents {
+		return nil, errors.New("Cannot confirm a payment if not using payment intents")
+	}
+
+	return s.confirm, nil
+}
+
+func (s *stripePaymentProvider) confirm(paymentID string) error {
+	_, err := paymentintent.Confirm(paymentID, nil)
+
+	if stripeErr, ok := err.(*stripe.Error); ok {
+		return payments.NewPaymentConfirmFailError(stripeErr.Msg)
+	}
+
+	return err
 }


### PR DESCRIPTION
Fixes #179 

**- Summary**

### New payments flow

- Client: Create a payment method and pass that to POST /orders/:order_id/payments
- Server: Create a PaymentIntent with the payment method from the client - report back if the payment needs more actions (including the client secret for the payment intent)
- Client: Completes additional action and calls POST /payments/:payment_id/confirm
- Server: Responds with the result of checking if the transaction is completed, updates payment status on order

### API docs for updated/new endpoints

#### `POST /orders/:order_id/payments` (updated)

**Payload:**
```js
{
  "provider": "stripe",
  "stripe_payment_method_id": "<the id>"
}
```

**Response:** Transaction object
*(state if 3D secure is pending)*
```js
{
  "id": "...", // transaction id
  "order_id": "...",
  "invoice_number": "...",
  "processor_id": "...",
  "user_id": "...",
  "amount": "...",
  "currency": "...",
  "status": "pending",
  "type": "...",
  "created_at": "...",
  "provider_metadata": {
    "payment_intent_secret": "<client secret>"
  }
}
```

#### `POST /payments/:payment_id/confirm` (new)

(payment id from previous response)

**Payload:** none

**Response:**

```js
{
  "id": "...",
  "order_id": "...",
  "invoice_number": "...",
  "processor_id": "...",
  "user_id": "...",
  "amount": "...",
  "currency": "...",
  "status": "paid",
  "type": "...",
  "created_at": "..."
}
```

**- Test plan**

*TBD*

**- Description for the changelog**

Support Strong Customer Authentication using Stripe with PaymentIntent

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://media.giphy.com/media/ND6xkVPaj8tHO/giphy-downsized.gif)