### PR TITLE
Refresh downloads on demand

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -188,7 +188,10 @@ func (a *API) orderRoutes(r *router) {
 			r.With(addGetBody).Post("/", a.PaymentCreate)
 		})
 
-		r.Get("/downloads", a.DownloadList)
+		r.Route("/downloads", func(r *router) {
+			r.Get("/", a.DownloadList)
+			r.Post("/refresh", a.DownloadRefresh)
+		})
 		r.Get("/receipt", a.ReceiptView)
 		r.Post("/receipt", a.ResendOrderReceipt)
 	})

--- a/api/download.go
+++ b/api/download.go
@@ -83,7 +83,6 @@ func (a *API) DownloadList(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	orderID := gcontext.GetOrderID(ctx)
 	log := getLogEntry(r)
-	claims := gcontext.GetClaims(ctx)
 
 	order := &models.Order{}
 	if orderID != "" {
@@ -114,6 +113,7 @@ func (a *API) DownloadList(w http.ResponseWriter, r *http.Request) error {
 	if order != nil {
 		query = query.Where(orderTable+".id = ?", order.ID)
 	} else {
+		claims := gcontext.GetClaims(ctx)
 		query = query.Where(orderTable+".user_id = ?", claims.Subject)
 	}
 

--- a/api/download_test.go
+++ b/api/download_test.go
@@ -1,7 +1,11 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/netlify/gocommerce/models"
@@ -18,4 +22,71 @@ func TestDownloadList(t *testing.T) {
 		extractPayload(t, http.StatusOK, recorder, &downloads)
 		assert.Len(t, downloads, 1)
 	})
+}
+
+func currentDownloads(test *RouteTest) []models.Download {
+	recorder := test.TestEndpoint(http.MethodGet, "/downloads", nil, test.Data.testUserToken)
+
+	downloads := []models.Download{}
+	extractPayload(test.T, http.StatusOK, recorder, &downloads)
+	return downloads
+}
+
+type DownloadMeta struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+}
+
+func startTestSiteWithDownloads(t *testing.T, downloads []*DownloadMeta) *httptest.Server {
+	downloadsList, err := json.Marshal(downloads)
+	assert.NoError(t, err)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/i/believe/i/can/fly":
+			fmt.Fprintf(w, productMetaFrame(`
+				{"sku": "123-i-can-fly-456", "downloads": %s}`),
+				string(downloadsList),
+			)
+		}
+	}))
+}
+
+func TestDownloadRefresh(t *testing.T) {
+	test := NewRouteTest(t)
+	downloadsBefore := currentDownloads(test)
+
+	testSite := startTestSiteWithDownloads(t, []*DownloadMeta{
+		&DownloadMeta{
+			Title: "Updated Download",
+			URL:   "/my/special/new/url",
+		},
+	})
+	defer testSite.Close()
+	test.Config.SiteURL = testSite.URL
+
+	url := fmt.Sprintf("/orders/%s/downloads/refresh", test.Data.firstOrder.ID)
+	recorder := test.TestEndpoint(http.MethodPost, url, nil, test.Data.testUserToken)
+	body, err := ioutil.ReadAll(recorder.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, recorder.Code, "Failure: %s", string(body))
+
+	downloadsAfter := currentDownloads(test)
+
+	assert.Equal(t, len(downloadsBefore)+1, len(downloadsAfter))
+	exists := false
+	for _, download := range downloadsAfter {
+		found := false
+		for _, prev := range downloadsBefore {
+			if download.ID == prev.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			assert.Equal(t, "/my/special/new/url", download.URL)
+			assert.Equal(t, "123-i-can-fly-456", download.Sku)
+			exists = true
+		}
+	}
+	assert.True(t, exists)
 }

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -418,35 +418,34 @@ func signInstanceRequest(req *http.Request, instanceID string, jwtSecret string)
 // TEST SITE
 // ------------------------------------------------------------------------------------------------
 
+func productMetaFrame(meta string) string {
+	return fmt.Sprintf(`<!doctype html>
+<html>
+<head><title>Test Product</title></head>
+<body>
+	<script class="gocommerce-product">
+		%s
+	</script>
+</body>
+</html>`,
+	meta)
+}
+
 func handleTestProducts(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/simple-product":
-		fmt.Fprintln(w, `<!doctype html>
-			<html>
-			<head><title>Test Product</title></head>
-			<body>
-				<script class="gocommerce-product">
-				{"sku": "product-1", "title": "Product 1", "type": "Book", "prices": [
-					{"amount": "9.99", "currency": "USD"}
-				]}
-				</script>
-			</body>
-			</html>`)
+		fmt.Fprintln(w, productMetaFrame(`
+			{"sku": "product-1", "title": "Product 1", "type": "Book", "prices": [
+				{"amount": "9.99", "currency": "USD"}
+			]}`))
 	case "/bundle-product":
-		fmt.Fprintln(w, `<!doctype html>
-			<html>
-			<head><title>Test Product</title></head>
-			<body>
-				<script class="gocommerce-product">
-				{"sku": "product-1", "title": "Product 1", "type": "Book", "prices": [
-					{"amount": "9.99", "currency": "USD", "items": [
-						{"amount": "7.00", "type": "Book"},
-						{"amount": "2.99", "type": "E-Book"}
-					]}
+		fmt.Fprintln(w, productMetaFrame(`
+			{"sku": "product-1", "title": "Product 1", "type": "Book", "prices": [
+				{"amount": "9.99", "currency": "USD", "items": [
+					{"amount": "7.00", "type": "Book"},
+					{"amount": "2.99", "type": "E-Book"}
 				]}
-				</script>
-			</body>
-			</html>`)
+			]}`))
 	default:
 		w.WriteHeader(http.StatusNotFound)
 	}


### PR DESCRIPTION
Preparation step for #128

**- Summary**

This feature enables users to get access to downloads which have been added to products from their orders after their purchase. Changes in the product metadata are going to be picked up.

Use the endpoint `/orders/{order_id}/downloads/refresh` to fetch updates on demand.

There is an unfinished implementation of an automatic, periodic refresh task that is planned to be introduced soon. This is a first step.

**- Test plan**

There is a http test for the `/orders/{order_id}/downloads/refresh` endpoint

**- Description for the changelog**

Refresh order downloads periodically and on demand

**- A picture of a cute animal (not mandatory but encouraged)**

![a cat and a dolphin](https://media.giphy.com/media/13eFBWrZEnJTGM/giphy.gif)