### PR TITLE
Remove deprecated payments through stripe charges

### DIFF
--- a/api/payments.go
+++ b/api/payments.go
@@ -535,8 +535,7 @@ func createPaymentProviders(c *conf.Configuration) (map[string]payments.Provider
 	provs := map[string]payments.Provider{}
 	if c.Payment.Stripe.Enabled {
 		p, err := stripe.NewPaymentProvider(stripe.Config{
-			SecretKey:         c.Payment.Stripe.SecretKey,
-			UsePaymentIntents: c.Payment.Stripe.UsePaymentIntents,
+			SecretKey: c.Payment.Stripe.SecretKey,
 		})
 		if err != nil {
 			return nil, err

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -68,8 +68,6 @@ type Configuration struct {
 			Enabled   bool   `json:"enabled"`
 			PublicKey string `json:"public_key" split_words:"true"`
 			SecretKey string `json:"secret_key" split_words:"true"`
-
-			UsePaymentIntents bool `json:"use_payment_intents" split_words:"true"`
 		} `json:"stripe"`
 		PayPal struct {
 			Enabled  bool   `json:"enabled"`


### PR DESCRIPTION
**- Summary**

The Stripe payment provider was recently migrated to use the new PaymentIntent API.
This is required for EU countries as of Sept 14th 2019.
That change was behind a feature flag.
This change makes PaymentIntents the default and removes the flag.

**- Test plan**

n/a

**- Description for the changelog**

Default to PaymentIntents for Stripe
