### PR TITLE
Updating response for succesful `/claims` request

### DIFF
--- a/api/order.go
+++ b/api/order.go
@@ -145,7 +145,8 @@ func (a *API) ClaimOrders(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	log.Info("Finished updating")
-	return sendJSON(w, http.StatusNoContent, "")
+	w.WriteHeader(http.StatusNoContent)
+	return nil
 }
 
 // ReceiptView renders an HTML receipt for an order


### PR DESCRIPTION


<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gocommerce/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

When a 204 is sent, no content is allowed. But using `sendJSON` creates
a response body with empty content and a "Content-Type" header. This change
sets the status as 204, but returns no content as the spec requires.

fixes #189 

**- Test plan**

Call /claims with a proper request, and the error llog mentioned in #189 will not appear

**- Description for the changelog**

Removed the body of the 204 response on a successful call to `/claims`

