### PR TITLE
Make `api` service depend on `db` service in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - 8080:8080
     networks:
       - db
+    depends_on:
+      - db
 
   db:
     image: mysql:5.7


### PR DESCRIPTION


<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/gocommerce/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
When first running this with docker-compose, the `api` fails immediately
because the `db` service is not yet running. This adds `depends_on` to
make sure the `db` service is running before the `api` service.

**- Test plan**

run `docker-compose up` and make sure `db` runs before `api` starts

**- Description for the changelog**

Ensure `db` service runs before `api` service when running `docker-compose`

