### PR TITLE
Add logger to mailer

### DIFF
--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/netlify/gocommerce/conf"
 	"github.com/netlify/gocommerce/models"
 	"github.com/netlify/mailme"
+	"github.com/sirupsen/logrus"
 )
 
 // Mailer will send mail and use templates from the site for easy mail styling
@@ -68,6 +69,7 @@ func NewMailer(smtp conf.SMTPConfiguration, instanceConfig *conf.Configuration) 
 				"price":          price,
 				"hasProductType": hasProductType,
 			},
+			Logger: logrus.New(),
 		},
 	}
 }


### PR DESCRIPTION
Fetching mailer templates is panicking because a nil logger is being passed to `nfhttp.SafeHttpClient` in mailme. This fixes that by creating the logger on the Mailer.