### PR TITLE
Pass request logger to mailer

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -24,7 +24,7 @@ func TestTraceWrapper(t *testing.T) {
 	config.Payment.Stripe.Enabled = true
 	config.Payment.Stripe.SecretKey = "secret"
 
-	ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, config, "")
+	ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, config, "", logrus.New())
 	require.NoError(t, err)
 	api := NewAPIWithVersion(ctx, globalConfig, logrus.StandardLogger(), nil, "")
 

--- a/api/payments_test.go
+++ b/api/payments_test.go
@@ -237,7 +237,7 @@ func TestPaymentsRefund(t *testing.T) {
 
 		globalConfig := new(conf.GlobalConfiguration)
 		provider := &memProvider{name: payments.StripeProvider}
-		ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, test.Config, "")
+		ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, test.Config, "", logrus.New())
 		require.NoError(t, err)
 		ctx = gcontext.WithPaymentProviders(ctx, map[string]payments.Provider{payments.StripeProvider: provider})
 
@@ -628,7 +628,7 @@ func TestPaymentPreauthorize(t *testing.T) {
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
 
 			globalConfig := new(conf.GlobalConfiguration)
-			ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, test.Config, "")
+			ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, test.Config, "", logrus.New())
 			require.NoError(t, err)
 			NewAPIWithVersion(ctx, test.GlobalConfig, logrus.StandardLogger(), test.DB, "").handler.ServeHTTP(recorder, req)
 
@@ -669,7 +669,7 @@ func TestPaymentPreauthorize(t *testing.T) {
 			req.Header.Set("Content-Type", "application/json")
 
 			globalConfig := new(conf.GlobalConfiguration)
-			ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, test.Config, "")
+			ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, test.Config, "", logrus.New())
 			require.NoError(t, err)
 			NewAPIWithVersion(ctx, test.GlobalConfig, logrus.StandardLogger(), test.DB, "").handler.ServeHTTP(recorder, req)
 

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -384,7 +384,7 @@ func (r *RouteTest) TestEndpoint(method string, url string, body io.Reader, toke
 		require.NoError(r.T, signHTTPRequest(req, token, r.Config.JWT.Secret))
 	}
 	globalConfig := new(conf.GlobalConfiguration)
-	ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, r.Config, "")
+	ctx, err := WithInstanceConfig(context.Background(), globalConfig.SMTP, r.Config, "", logrus.New())
 	require.NoError(r.T, err)
 	NewAPIWithVersion(ctx, r.GlobalConfig, logrus.StandardLogger(), r.DB, "").handler.ServeHTTP(recorder, req)
 

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -32,7 +32,7 @@ func serve(globalConfig *conf.GlobalConfiguration, log logrus.FieldLogger, confi
 	}
 	defer bgDB.Close()
 
-	ctx, err := api.WithInstanceConfig(context.Background(), globalConfig.SMTP, config, "")
+	ctx, err := api.WithInstanceConfig(context.Background(), globalConfig.SMTP, config, "", log)
 	if err != nil {
 		log.Fatalf("Error loading instance config: %+v", err)
 	}

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -29,7 +29,7 @@ type MailSubjects struct {
 }
 
 // NewMailer returns a new authlify mailer
-func NewMailer(smtp conf.SMTPConfiguration, instanceConfig *conf.Configuration) Mailer {
+func NewMailer(smtp conf.SMTPConfiguration, instanceConfig *conf.Configuration, log logrus.FieldLogger) Mailer {
 	if smtp.Host == "" && instanceConfig.SMTP.Host == "" {
 		return newNoopMailer()
 	}
@@ -69,7 +69,7 @@ func NewMailer(smtp conf.SMTPConfiguration, instanceConfig *conf.Configuration) 
 				"price":          price,
 				"hasProductType": hasProductType,
 			},
-			Logger: logrus.New(),
+			Logger: log,
 		},
 	}
 }

--- a/mailer/mailer_test.go
+++ b/mailer/mailer_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	"github.com/netlify/gocommerce/conf"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNoopMailer(t *testing.T) {
 	smtp := conf.SMTPConfiguration{}
 	conf := &conf.Configuration{}
-	m := NewMailer(smtp, conf)
+	m := NewMailer(smtp, conf, logrus.New())
 	assert.IsType(t, &noopMailer{}, m)
 }
 
@@ -21,6 +22,6 @@ func TestTemplateMailer(t *testing.T) {
 	}
 	conf := &conf.Configuration{}
 	conf.SMTP.AdminEmail = "test@example.com"
-	m := NewMailer(smtp, conf)
+	m := NewMailer(smtp, conf, logrus.New())
 	assert.IsType(t, &mailer{}, m)
 }


### PR DESCRIPTION
Instead of creating a new logger, pass a logger based on the current request to the Mailer.