### PR TITLE
Upgrade to Go 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.17
 
 RUN useradd -m netlify
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,6 @@ module github.com/netlify/gocommerce
 require (
 	github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20170623214735-571947b0f240
 	github.com/PuerkitoBio/goquery v1.1.0
-	github.com/andybalholm/cascadia v0.0.0-20161224141413-349dd0209470 // indirect
-	github.com/denisenkom/go-mssqldb v0.0.0-20190906004059-62cf760a6c9e // indirect
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/golang-jwt/jwt/v4 v4.2.0
@@ -12,7 +10,6 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lib/pq v1.1.1
-	github.com/logpacker/PayPal-Go-SDK v2.0.5+incompatible // indirect
 	github.com/mattes/vat v0.0.0-20160607175015-805d21ad0739
 	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/mitchellh/mapstructure v1.1.2
@@ -21,15 +18,41 @@ require (
 	github.com/pariz/gountries v0.0.0-20171019111738-adb00f6513a3
 	github.com/pborman/uuid v0.0.0-20160209185913-a97ce2ca70fa
 	github.com/pkg/errors v0.8.1
-	github.com/plutov/paypal v2.0.5+incompatible // indirect
 	github.com/rs/cors v1.6.0
 	github.com/sebest/xff v0.0.0-20160910043805-6c115e0ffa35
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.4-0.20190321000552-67fc4837d267
 	github.com/stretchr/testify v1.4.0
 	github.com/stripe/stripe-go v62.9.0+incompatible
-	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
 
-go 1.13
+require (
+	cloud.google.com/go v0.37.4 // indirect
+	github.com/andybalholm/cascadia v0.0.0-20161224141413-349dd0209470 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/denisenkom/go-mssqldb v0.0.0-20190906004059-62cf760a6c9e // indirect
+	github.com/golang/protobuf v1.3.1 // indirect
+	github.com/hashicorp/golang-lru v0.5.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/logpacker/PayPal-Go-SDK v2.0.5+incompatible // indirect
+	github.com/netlify/netlify-commons v0.32.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	go.opencensus.io v0.20.1 // indirect
+	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
+	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 // indirect
+	golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f // indirect
+	golang.org/x/text v0.3.2 // indirect
+	google.golang.org/api v0.3.1 // indirect
+	google.golang.org/appengine v1.6.0 // indirect
+	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 // indirect
+	google.golang.org/grpc v1.19.0 // indirect
+	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/gomail.v2 v2.0.0-20150902115704-41f357289737 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+)
+
+go 1.17

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,6 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/plutov/paypal v2.0.5+incompatible h1:i5ma4HiHO0MUvJGHaKkL2aqOj0B19q8WoJm1jgzQjlM=
-github.com/plutov/paypal v2.0.5+incompatible/go.mod h1:jOStyiXeDrJ9dHA/yVUB2ahyYPjd5rMXUZ4N7XM37nQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=


### PR DESCRIPTION
**- Summary**

Follow up for #222 

It needs at least Go 1.15, but it shouldn't hurt to go to lastest.

**- Test plan**

Existing tests and staging.

**- Description for the changelog**

Upgrade Go to 1.17

**- A picture of a cute animal (not mandatory but encouraged)**
