### PR TITLE
fix Warning and note in sqlite3-binding.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ arch = amd64
 
 build:
 	@echo "Making gocommerce for $(os)/$(arch)"
-	GOOS=$(os) GOARCH=$(arch) go build -ldflags "-X github.com/netlify/gocommerce/cmd.Version=`git rev-parse HEAD`"
+	GOOS=$(os) GOARCH=$(arch) CGO_CFLAGS="-g -O2 -Wno-return-local-addr" go build -ldflags "-X github.com/netlify/gocommerce/cmd.Version=`git rev-parse HEAD`"
 
 build_linux: override os=linux
 build_linux: build


### PR DESCRIPTION
`sqlite3-binding.c: In function ‘sqlite3SelectNew’:
sqlite3-binding.c:128049:10: warning: function may return address of local variable [-Wreturn-local-addr]
128049 |   return pNew;
       |          ^~~~
sqlite3-binding.c:128009:10: note: declared here
128009 |   Select standin;
       |          ^~~~~~~`