### PR TITLE
feature : multi-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
-FROM golang:1.17
+FROM golang:1.17 AS build
 
 RUN useradd -m netlify
 
-ADD . /src
-RUN cd /src && make deps build_linux && mv gocommerce /usr/local/bin/
+WORKDIR /src
+COPY . .
+
+# Build the application
+RUN make deps build_linux
+RUN mv gocommerce /usr/local/bin/
+
+# Stage 2: Create a minimal image
+FROM scratch
+
+# Copy the built binary from the first stage
+COPY --from=build /usr/local/bin/gocommerce /usr/local/bin/gocommerce
 
 USER netlify
-CMD ["gocommerce"]
 EXPOSE 8080
+
+CMD ["gocommerce"]
+


### PR DESCRIPTION
In the Dockerfile, there are two stages. The first stage (`build`) builds the application using the specified Go version, and the second stage (`scratch`) creates a minimal image without any operating system or additional layers. The binary file built in the first stage is copied into the second stage. This approach helps reduce the overall file size of the Docker image.
